### PR TITLE
Fix gtk2/gtk3 conflict (solves issue #1)

### DIFF
--- a/extensions/PrintDefault.py
+++ b/extensions/PrintDefault.py
@@ -17,10 +17,14 @@ from pwiki import PluginManager
 
 from pwiki.StringOps import unescapeWithRe, urlFromPathname
 
+from pwiki import WikiHtmlView
 
-try:
-    from pwiki.WikiHtmlViewWK import WKHtmlWindow
-except:
+if WikiHtmlView.WikiHtmlViewWK is not None:
+    try:
+        from pwiki.WikiHtmlViewWK import WKHtmlWindow
+    except:
+        WKHtmlWindow = None
+else:
     WKHtmlWindow = None
 
 

--- a/extensions/PrintDefault.py
+++ b/extensions/PrintDefault.py
@@ -85,7 +85,7 @@ class PlainTextPrint:
             if panel.fontDesc:
                 font = wx.FontFromNativeInfoString(panel.fontDesc)
                 fontdata.SetInitialFont(font)
-                
+
             dlg = wx.FontDialog(panel, fontdata)
             try:
                 if dlg.ShowModal() == wx.ID_OK:
@@ -97,7 +97,7 @@ class PlainTextPrint:
 
         ctrls.tfWikiPageSeparator.SetValue(config.get("main",
                 "print_plaintext_wpseparator"))
-                
+
         panel.fontDesc = config.get("main", "print_plaintext_font")
 
         wx.EVT_BUTTON(panel, GUI_ID.btnChoosePlainTextFont,
@@ -114,7 +114,7 @@ class PlainTextPrint:
         Returns the version of the additional options information returned
         by getAddOpt(). If the return value is -1, the version info can't
         be stored between application sessions.
-        
+
         Otherwise, the addopt information can be stored between sessions
         and can later handled back to the doPreview() or doPrint() method of
         the object without previously showing the print dialog (currently
@@ -159,7 +159,7 @@ class PlainTextPrint:
                 addOpt[:2]
 
         ctrls = XrcControls(addoptpanel)
-        
+
         addoptpanel.fontDesc = fontDesc
         ctrls.tfWikiPageSeparator.SetValue(wpseparator)
 
@@ -181,10 +181,10 @@ class PlainTextPrint:
 #                     "main", "print_plaintext_wpseparator"))
 #         except:
 #             separator = u"\n\n\n\n"   # TODO Error message
-#         
+#
 #         return separator.join(contents)
-            
-            
+
+
     def setContext(self, printer, wikiDocument, wordList, printType, addopt):
         self.wikiDocument = wikiDocument
         self.wordList = wordList
@@ -199,7 +199,7 @@ class PlainTextPrint:
         """
         Part of "Prints" plugin API. A Printing.Printer object calls this
         to print a list of wiki words.
-        
+
         printer -- Printer object
         wikiDocument -- WikiDataManager aka WikiDocument object
         wordList -- list of wiki words to print
@@ -212,9 +212,9 @@ class PlainTextPrint:
 
         printout = PlainTextPrintout(text, self.printer, addopt)
         printer = wx.Printer(wx.PrintDialogData(self.printer.getPrintData()))
-        
+
         config = self.mainControl.getConfig()
-        
+
         config.set("main", "print_plaintext_font", addopt[0])
         config.set("main", "print_plaintext_wpseparator", addopt[1])
 
@@ -225,7 +225,7 @@ class PlainTextPrint:
         """
         Part of "Prints" plugin API. A Printing.Printer object calls this
         to show a print preview for a list of wiki words.
-        
+
         printer -- Printer object
         wikiDocument -- WikiDataManager aka WikiDocument object
         wordList -- list of wiki words to print
@@ -235,7 +235,7 @@ class PlainTextPrint:
         """
         self.setContext(printer, wikiDocument, wordList, printType, addopt)
         text = self._buildText()
-        
+
         pddata = wx.PrintDialogData(self.printer.getPrintData())
         printout = PlainTextPrintout(text, self.printer, addopt)
         printout2 = PlainTextPrintout(text, self.printer, addopt)
@@ -268,7 +268,7 @@ class PlainTextPrintout(wx.Printout):
         self.fontDesc = addOpt[0]
         self.wpseparator = addOpt[1]
 
-        
+
     def HasPage(self, pageNum):
         return len(self.pageCharStartIndex) > pageNum
 
@@ -284,7 +284,7 @@ class PlainTextPrintout(wx.Printout):
         (self.mm2logUnitsFactor).
 
         Must be called before using the conversion functions.
-        
+
         Code taken from a wxWidgets sample
         """
         # You might use THIS code to set the printer DC to ROUGHLY reflect
@@ -341,7 +341,7 @@ class PlainTextPrintout(wx.Printout):
         if len(self.pageCharStartIndex) <= pageNum:
             # Request for a non-existing page
             return True
-            
+
         return self._printAndIndex(pageNum)
 
 
@@ -389,7 +389,7 @@ class PlainTextPrintout(wx.Printout):
 
         textpos = self.pageCharStartIndex[pagepos]
         text = self.text
-        
+
         if pageNum == -1:
             # Build a list of cuttedText. Each item is either a newline,
             # a new page command '\f', one or more spaces or one or more
@@ -400,24 +400,24 @@ class PlainTextPrintout(wx.Printout):
                 lastCharPos = len(text)
             else:
                 lastCharPos = self.pageCharStartIndex[pageNum + 1]
-                
+
             cuttedText = _CUT_RE.findall(
                     text[self.pageCharStartIndex[pageNum]:lastCharPos])
 
         currLine = u""
         currLineWidth = 0
         w, stepY, d, e = dc.GetFullTextExtent("aaaaaaaa")
-        
+
         posxLu, posyLu = printRectLu[0:2]
         prAreaWidth = printRectLu[2] - printRectLu[0]
-        
+
         i = 0
         while i < len(cuttedText):    # _CUT_RE.finditer(text[textpos:]):
             part = cuttedText[i]
-            
+
             flushLine = False
             flushPage = False
-            
+
             if part[0] == u" ":
                 # One or more spaces -> Append to current line if possible,
                 # throw away and start new print line if not
@@ -483,12 +483,12 @@ class PlainTextPrintout(wx.Printout):
                 if posyLu + stepY > printRectLu[3]:
                     # End of page reached
                     flushPage = True
-                    
+
             if flushPage:
                 if pageNum != -1 or textpos == len(text):
                     break
                 pagepos += 1
-                
+
 #                 print "PagePos", pagepos
 #                 if pagepos > 100: break
                 posyLu = printRectLu[1]
@@ -496,7 +496,7 @@ class PlainTextPrintout(wx.Printout):
 
 
         dc.SetFont(wx.NullFont)
-        
+
         return True
 
 
@@ -519,19 +519,19 @@ class HtmlPrint:
 #         if not u"html_multi" in exportTypes and \
 #                 not u"html_single" in exportTypes:
 #             return ()
-# 
+#
 #         res = wx.xrc.XmlResource.Get()
 #         htmlPanel = res.LoadPanel(guiparent, "ExportSubHtml")
 #         ctrls = XrcControls(htmlPanel)
 #         config = self.mainControl.getConfig()
-# 
+#
 #         ctrls.cbPicsAsLinks.SetValue(config.getboolean("main",
 #                 "html_export_pics_as_links"))
 #         ctrls.chTableOfContents.SetSelection(config.getint("main",
 #                 "export_table_of_contents"))
 #         ctrls.tfHtmlTocTitle.SetValue(config.get("main",
 #                 "html_toc_title"))
-# 
+#
 #         return (
 #             (u"html_multi", htmlPanel),
 #             (u"html_single", htmlPanel)
@@ -546,7 +546,7 @@ class HtmlPrint:
 #         if addoptpanel is None:
 #             # Return default set in options
 #             config = self.mainControl.getConfig()
-# 
+#
 #             return ( boolToInt(config.getboolean("main",
 #                     "html_export_pics_as_links")),
 #                     config.getint("main", "export_table_of_contents"),
@@ -555,11 +555,11 @@ class HtmlPrint:
 #                      )
 #         else:
 #             ctrls = XrcControls(addoptpanel)
-# 
+#
 #             picsAsLinks = boolToInt(ctrls.cbPicsAsLinks.GetValue())
 #             tableOfContents = ctrls.chTableOfContents.GetSelection()
 #             tocTitle = ctrls.tfHtmlTocTitle.GetValue()
-# 
+#
 #             return (picsAsLinks, tableOfContents, tocTitle, u"volatile")
 
 
@@ -567,11 +567,11 @@ class HtmlPrint:
         pass
 #         picsAsLinks, tableOfContents, tocTitle, volatileDir = \
 #                 addOpt[:4]
-# 
+#
 #         # volatileDir is currently ignored
-# 
+#
 #         ctrls = XrcControls(addoptpanel)
-# 
+#
 #         ctrls.cbPicsAsLinks.SetValue(picsAsLinks != 0)
 #         ctrls.chTableOfContents.SetSelection(tableOfContents)
 #         ctrls.tfHtmlTocTitle.SetValue(tocTitle)
@@ -593,7 +593,7 @@ class HtmlPrint:
         self.tempFileSet = TempFileSet()
         exporterInstance.tempFileSet = self.tempFileSet
         exporterInstance.styleSheet = u""
-        
+
         realfp = StringIO.StringIO()
         exporterInstance.exportHtmlMultiFile(realfp=realfp, tocMode=0)
 
@@ -603,7 +603,7 @@ class HtmlPrint:
         self.tempFileSet.clear()
         self.tempFileSet = None
 
-            
+
     def setContext(self, printer, wikiDocument, wordList, printType, addopt):
         self.wikiDocument = wikiDocument
         self.wordList = wordList
@@ -613,10 +613,10 @@ class HtmlPrint:
     def doPrint(self, printer, wikiDocument, wordList, printType, addopt):
         self.setContext(printer, wikiDocument, wordList, printType, addopt)
         text = self._buildHtml()
-        
+
         try:
             printout = HtmlPrintout(text, self.printer)
-            
+
             pData = wx.PrintDialogData(self.printer.getPrintData())
             printer = wx.Printer(pData)
 
@@ -628,17 +628,17 @@ class HtmlPrint:
     def doPreview(self, printer, wikiDocument, wordList, printType, addopt):
         self.setContext(printer, wikiDocument, wordList, printType, addopt)
         text = self._buildHtml()
-        
-        try:        
+
+        try:
             pddata = wx.PrintDialogData(self.printer.getPrintData())
             printout = HtmlPrintout(text, self.printer)
             printout2 = HtmlPrintout(text, self.printer)
-    
+
             preview = wx.PrintPreview(printout, printout2, pddata)
-    
+
             frame = wx.PreviewFrame(preview, self.mainControl, _(u"Print Preview"),
                     style=wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT)
-    
+
             frame.Initialize()
             frame.SetPosition(self.mainControl.GetPosition())
             frame.SetSize(self.mainControl.GetSize())
@@ -651,7 +651,7 @@ class HtmlPrint:
 class HtmlPrintout(wx.html.HtmlPrintout):
     def __init__(self, text, printer):
         wx.html.HtmlPrintout.__init__(self)
-        
+
         self.printer = printer
         self.SetHtmlText(text)
         psddata = self.printer.getPageSetupDialogData()
@@ -659,19 +659,19 @@ class HtmlPrintout(wx.html.HtmlPrintout):
         br = psddata.GetMarginBottomRight()
 
         self.SetMargins(tl.y, br.y, tl.x, br.x, spaces=0)
-        
+
 
 
 #     def _updateTempFilePrefPath(self):
 #         wikiDocument = self.presenter.getWikiDocument()
-# 
+#
 #         if wikiDocument is not None:
 #             self.exporterInstance.tempFileSet.setPreferredPath(
 #                     wikiDocument.getWikiTempDir())
 #         else:
 #             self.exporterInstance.tempFileSet.setPreferredPath(None)
 
-        
+
 #         self.SetHtmlText(u"ab<br />\n" * 5000)
 
 
@@ -702,7 +702,7 @@ class HtmlWKPrint(HtmlPrint):
         self.tempFileSet = TempFileSet()
         exporterInstance.tempFileSet = self.tempFileSet
         exporterInstance.styleSheet = u""
-        
+
         htpath = self.tempFileSet.createTempFile(
                     u"", ".html", relativeTo="").decode("latin-1")
 
@@ -785,18 +785,18 @@ if WKHtmlWindow:
             self.html_preview.PizzaMagic()
             url = "file:" + urlFromPathname(htpath)
             self.html_preview.LoadUrl(url)
-            
-        
+
+
 #         def Print(self):
 #             self.html_preview.Print()
 
-            
+
     class WKPrintFrame(wx.Frame):
         """Frame to contain webkit ctrl panel"""
         def __init__(self, htpath):
             wx.Frame.__init__(self, None)
             self.html_panel = WKPrintPanel(self, htpath)
-        
+
         def print_full(self, print_op, opCode):
             return self.html_panel.html_preview.getWebkitWebView()\
                     .get_main_frame().print_full(print_op, opCode)

--- a/lib/pwiki/Configuration.py
+++ b/lib/pwiki/Configuration.py
@@ -731,7 +731,7 @@ GLOBALDEFAULTS = {
     ("main", "editor_margin_bg_color"): "",  # Background color of margins in the editor except fold margin
     ("main", "editor_caret_color"): "",  # Color of caret in the editor
 
-    # Clipboard catcher (Windows only)
+    # Clipboard catcher (some OS')
     ("main", "clipboardCatcher_prefix"): ur"",  # Prefix to prepend before each caught clipboard snippet
     ("main", "clipboardCatcher_suffix"): ur"\n",  # Suffix to append after each caught clipboard snippet
     ("main", "clipboardCatcher_filterDouble"): "True",  # If same text shall be inserted twice (or more often)

--- a/lib/pwiki/GtkHacks.py
+++ b/lib/pwiki/GtkHacks.py
@@ -24,7 +24,7 @@ gobject.threads_init()
 class BaseFakeInterceptor:
     def __init__(self):
         pass
-        
+
     def addInterceptCollection(self, interceptCollection):
         """
         Called automatically if interceptor is added to an
@@ -63,7 +63,7 @@ class BaseFakeInterceptor:
         uninterception doesn't happen (this may be dangerous).
         """
         return True
-        
+
     def stopAfterUnintercept(self, interceptCollection):
         """
         Called for each interceptor of a collection after the actual
@@ -76,7 +76,7 @@ class BaseFakeInterceptor:
 #         """
 #         Called for each Windows message to the intercepted window. This is
 #         the ANSI-style method, wide-char is not supported.
-#         
+#
 #         params -- WinProcParams object containing parameters the function can
 #                 modify and a returnValue which can be set to prevent
 #                 from calling interceptWinProc functions
@@ -92,9 +92,9 @@ class FakeInterceptCollection:
     """
     def __init__(self, interceptors=None):
         self.interceptors = []
-        
+
         self.hWnd = None  # Stored, but unused
-        
+
         if interceptors is not None:
             for icept in interceptors:
                 self.addInterceptor(icept)
@@ -114,10 +114,10 @@ class FakeInterceptCollection:
 
         for icept in self.interceptors:
             icept.removeInterceptCollection(self)
-        
+
         self.interceptors = []
-    
-    
+
+
     def close(self):
         self.clear()
 
@@ -125,35 +125,35 @@ class FakeInterceptCollection:
     def start(self, callingWindow):
         if self.isIntercepting():
             return False
-            
+
         for icept in self.interceptors:
             if not icept.startBeforeIntercept(self):
                 return False
-        
+
         self.intercept(callingWindow)
-        
+
         for icept in self.interceptors:
             try:
                 icept.startAfterIntercept(self)
             except:
                 traceback.print_exc()
-                
+
         return True
 
 
     def stop(self):
         if not self.isIntercepting():
             return False
-            
+
         for icept in self.interceptors:
             try:
                 if not icept.stopBeforeUnintercept(self):
                     return False
             except:
                 traceback.print_exc()
-        
+
         self.unintercept()
-        
+
         for icept in self.interceptors:
             try:
                 icept.stopAfterUnintercept(self)
@@ -178,10 +178,10 @@ class FakeInterceptCollection:
     def unintercept(self):
         if not self.isIntercepting():
             return
-            
+
 #         SetWindowLong(c_int(self.hWnd), c_int(GWL_WNDPROC),
 #                 c_int(self.oldWndProc))
-# 
+#
 #         self.oldWinProc = None
 #         self.ctWinProcStub = None
         self.hWnd = None
@@ -189,17 +189,17 @@ class FakeInterceptCollection:
 
     def isIntercepting(self):
         return self.hWnd is not None
-        
+
 
 #     def _lastWinProc(self, params):
 #         """
 #         This default function reacts only on a WM_DESTROY message and
 #         stops interception. All messages are sent to the original WinProc
 #         """
-#         
+#
 #         if params.uMsg == WM_DESTROY and params.hWnd == self.hWnd:
 #             self.stop()
-# 
+#
 #         params.returnValue = CallWindowProc(c_int(self.oldWndProc),
 #                 c_int(params.hWnd), c_uint(params.uMsg),
 #                 c_uint(params.wParam), c_ulong(params.lParam))
@@ -208,20 +208,20 @@ class FakeInterceptCollection:
 #     def winProc(self, hWnd, uMsg, wParam, lParam):
 #         params = self.winParams
 #         params.set(hWnd, uMsg, wParam, lParam)
-# 
+#
 #         for icept in self.interceptors:
 #             try:
 #                 icept.interceptWinProc(self, params)
 #             except:
 #                 traceback.print_exc()
-#             
+#
 #             if params.returnValue is not None:
 #                 return params.returnValue
-#         
+#
 #         self._lastWinProc(params)
 #         return params.returnValue
 
-        
+
 
 
 
@@ -235,7 +235,7 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
 
     def __init__(self, mainControl):
         BaseFakeInterceptor.__init__(self)
-        
+
 #         self.hWnd = None
         self.gtkDefClipboard = None
         self.gtkConnHandle = None
@@ -257,7 +257,7 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
         """
         if self.gtkDefClipboard is not None:
             return
-        
+
         self.gtkDefClipboard = gtk.clipboard_get()
         self.gtkConnHandle = self.gtkDefClipboard.connect("owner-change",
                 lambda clp, evt: self.handleClipboardChange())
@@ -273,7 +273,7 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
         """
         if self.gtkDefClipboard is None:
             return
-        
+
         self.gtkDefClipboard.disconnect(self.gtkConnHandle)
         self.gtkConnHandle = None
         self.gtkDefClipboard = None
@@ -351,7 +351,7 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
 #         """
 #         Called for each Windows message to the intercepted window. This is
 #         the ANSI-style method, wide-char is not supported.
-#         
+#
 #         params -- WinProcParams object containing parameters the function can
 #                 modify and a returnValue which can be set to prevent
 #                 from calling interceptWinProc functions
@@ -360,18 +360,18 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
 #             if self.nextWnd == params.wParam:
 #                 # repair the chain
 #                 self.nextWnd = params.lParam
-#     
+#
 #             if self.nextWnd:  # Neither None nor 0
 #                 # pass the message to the next window in chain
 #                 SendMessage(c_int(self.nextWnd), c_int(params.uMsg),
 #                         c_uint(params.wParam), c_ulong(params.lParam))
-# 
+#
 #         elif params.uMsg == WM_DRAWCLIPBOARD:
 #             if self.ignoreNextCCMessage:
 #                 self.ignoreNextCCMessage = False
 #             else:
 #                 self.handleClipboardChange()
-# 
+#
 #             if self.nextWnd:  # Neither None nor 0
 #                 # pass the message to the next window in chain
 #                 SendMessage(c_int(self.nextWnd), c_int(params.uMsg),
@@ -423,7 +423,7 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
 
         if self.mode == ClipboardCatchFakeIceptor.MODE_OFF:
             return
-            
+
         if self.mainControl.getConfig().getboolean("main",
                 "clipboardCatcher_filterDouble", True) and self.lastText == text:
             # Same text shall be inserted again
@@ -434,11 +434,11 @@ class ClipboardCatchFakeIceptor(BaseFakeInterceptor):
                 return
             self.wikiPage.appendLiveText(prefix + text + suffix)
             self.notifyUserOnClipboardChange()
-            
+
         elif self.mode == ClipboardCatchFakeIceptor.MODE_AT_CURSOR:
             self.mainControl.getActiveEditor().ReplaceSelection(prefix + text + suffix)
             self.notifyUserOnClipboardChange()
-            
+
         self.lastText = text
 
 

--- a/lib/pwiki/OsAbstract.py
+++ b/lib/pwiki/OsAbstract.py
@@ -11,19 +11,26 @@ from .StringOps import mbcsEnc, urlQuote, pathnameFromUrl, pathEnc
 
 # import WindowsHacks
 
-try:
-    import WindowsHacks
-except:
-    if SystemInfo.isWindows():
-        traceback.print_exc()
+
+if SystemInfo.isWindows():
+    try:
+        import WindowsHacks
+    except:
+        if SystemInfo.isWindows():
+            traceback.print_exc()
+        WindowsHacks = None
+else:
     WindowsHacks = None
 
-try:
-    import GtkHacks
-except:
-    import ExceptionLogger
-    ExceptionLogger.logOptionalComponentException(
-            "Initialize GTK hacks in OsAbstract.py")
+if SystemInfo.isWindows():
+    try:
+        import GtkHacks
+    except:
+        import ExceptionLogger
+        ExceptionLogger.logOptionalComponentException(
+                "Initialize GTK hacks in OsAbstract.py")
+        GtkHacks = None
+else:
     GtkHacks = None
 
 

--- a/lib/pwiki/OsAbstract.py
+++ b/lib/pwiki/OsAbstract.py
@@ -9,8 +9,7 @@ from . import SystemInfo
 from .StringOps import mbcsEnc, urlQuote, pathnameFromUrl, pathEnc
 
 
-# import WindowsHacks
-
+# WindowsHacks for some OS specials
 
 if SystemInfo.isWindows():
     try:
@@ -22,15 +21,14 @@ if SystemInfo.isWindows():
 else:
     WindowsHacks = None
 
-if SystemInfo.isWindows():
-    try:
-        import GtkHacks
-    except:
-        import ExceptionLogger
-        ExceptionLogger.logOptionalComponentException(
-                "Initialize GTK hacks in OsAbstract.py")
-        GtkHacks = None
-else:
+# GtkHacks for the Clipboard Catcher
+
+try:
+    import GtkHacks
+except:
+    import ExceptionLogger
+    ExceptionLogger.logOptionalComponentException(
+            "Initialize GTK hacks in OsAbstract.py")
     GtkHacks = None
 
 

--- a/lib/pwiki/OsAbstract.py
+++ b/lib/pwiki/OsAbstract.py
@@ -37,7 +37,7 @@ if SystemInfo.isWindows():
 else:
     def startFile(mainControl, link):
         # We need mainControl only for this version of startFile()
-        
+
         startPath = mainControl.getConfig().get("main", "fileLauncher_path", u"")
         if startPath == u"":
             wx.LaunchDefaultBrowser(link)
@@ -55,7 +55,7 @@ if SystemInfo.isWinNT() and WindowsHacks:
     moveFile = WindowsHacks.moveFile
     deleteFile = WindowsHacks.deleteFile
 else:
-    # TODO Mac version    
+    # TODO Mac version
     def copyFile(srcPath, dstPath):
         """
         Copy file from srcPath to dstPath. dstPath may be overwritten if
@@ -65,10 +65,10 @@ else:
         This currently just calls shutil.copy2() TODO!
         """
         dstDir = os.path.dirname(dstPath)
-            
+
         if not os.path.exists(pathEnc(dstDir)):
             os.makedirs(dstDir)
-    
+
         shutil.copy2(srcPath, dstPath)
 
     def moveFile(srcPath, dstPath):
@@ -77,11 +77,11 @@ else:
         existing already. dstPath must point to a file, not a directory.
         If some directories in dstPath do not exist, they are created.
         """
-        dstDir = os.path.dirname(dstPath)        
-    
+        dstDir = os.path.dirname(dstPath)
+
         if not os.path.exists(pathEnc(dstDir)):
             os.makedirs(dstDir)
-    
+
         shutil.move(srcPath, dstPath)
 
 
@@ -105,7 +105,7 @@ if SystemInfo.isWindows():
             if WindowsHacks.getLongPath(path1).lower() == \
                     WindowsHacks.getLongPath(path2).lower():
                 return True
-            
+
             return WindowsHacks.getLongPath(os.path.abspath(path1)).lower() == \
                     WindowsHacks.getLongPath(os.path.abspath(path2)).lower()
     else:
@@ -164,7 +164,7 @@ else:
             return GtkHacks.FakeInterceptCollection(interceptors)
         def createClipboardInterceptor(callingWindow):
             return GtkHacks.ClipboardCatchFakeIceptor(callingWindow)
-        
+
 
 if WindowsHacks:
     translateAcceleratorByKbLayout = WindowsHacks.translateAcceleratorByKbLayout


### PR DESCRIPTION
Fixes WikidPad's freezing on startup when running on Linux systems with GTK3 and wxPython3 (for example Fedora 22 and later). For some more infos see issue #1.

Note:
The diff list seems to be really long, but most lines are just removed trailing whitespace. Originally I put those removals into separate commits.