### PR TITLE
Avoid XRC-errors in option menu

### DIFF
--- a/WikidPad.xrc
+++ b/WikidPad.xrc
@@ -248,9 +248,7 @@
           <label>Rename dialog defaults</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -284,9 +282,7 @@
           <label>Temporary files</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -1289,9 +1285,7 @@
           <label>Image pasting</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -1385,9 +1379,7 @@
           <label>File pasting/dropping</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -1956,9 +1948,7 @@
         <object class="wxStaticText" name="">
           <label>Chronological View</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2052,9 +2042,7 @@
         <object class="wxStaticText" name="">
           <label>Timeline</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2084,9 +2072,7 @@
         <object class="wxStaticText" name="">
           <label>Versioning</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2131,9 +2117,7 @@
         <object class="wxStaticText" name="">
           <label>Wiki-wide history</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2178,9 +2162,7 @@
         <object class="wxStaticText" name="">
           <label>General</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2199,9 +2181,7 @@
         <object class="wxStaticText" name="">
           <label>Wiki-wide search</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2212,9 +2192,7 @@
         <object class="wxStaticText" name="">
           <label>  Defaults</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2260,9 +2238,7 @@
         <object class="wxStaticText" name="">
           <label>  Context characters</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2351,9 +2327,7 @@
               <label>Fast search defaults</label>
               <style></style>
               <font>
-                <style>default</style>
                 <weight>bold</weight>
-                <family>normal</family>
                 <underlined>0</underlined>
               </font>
             </object>
@@ -2416,9 +2390,7 @@
         <object class="wxStaticText" name="">
           <label>Incremental search</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -2486,8 +2458,6 @@
             <object class="wxStaticText">
               <label>Compatibility</label>
               <font>
-                <family>normal</family>
-                <style>default</style>
                 <weight>bold</weight>
                 <underlined>0</underlined>
               </font>
@@ -2613,8 +2583,6 @@
               <label>Change these only if you know what you are doing!</label>
               <fg>#A80000</fg>
               <font>
-                <family>normal</family>
-                <style>default</style>
                 <weight>bold</weight>
                 <underlined>0</underlined>
               </font>
@@ -2658,8 +2626,6 @@
             <object class="wxStaticText">
               <label>Editor timing</label>
               <font>
-                <family>normal</family>
-                <style>default</style>
                 <weight>bold</weight>
                 <underlined>0</underlined>
               </font>
@@ -2746,8 +2712,6 @@
             <object class="wxStaticText">
               <label>Tree timing</label>
               <font>
-                <family>normal</family>
-                <style>default</style>
                 <weight>bold</weight>
                 <underlined>0</underlined>
               </font>
@@ -3019,9 +2983,7 @@
           <label>Trashcan</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3147,9 +3109,7 @@
           <label>Heading of new pages</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3232,9 +3192,7 @@
           <label>Headings as aliases</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3272,9 +3230,7 @@
         <object class="wxStaticText" name="">
           <label>Versioning</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3360,9 +3316,7 @@
         <object class="wxStaticText" name="">
           <label>Tab history</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3416,9 +3370,7 @@
         <object class="wxStaticText" name="">
           <label>Wiki-wide history</label>
           <font>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3478,9 +3430,7 @@
           <label>File storage identity check</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3517,9 +3467,7 @@
           <label>File signature</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3558,9 +3506,7 @@
           <label>Miscellanous</label>
           <font>
             <size>8</size>
-            <style>default</style>
             <weight>bold</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>
@@ -3630,9 +3576,7 @@
           <label></label>
           <font>
             <size>12</size>
-            <style>default</style>
             <weight>normal</weight>
-            <family>normal</family>
             <underlined>0</underlined>
           </font>
         </object>


### PR DESCRIPTION
Removed some default entries from WikidPad.xrc

More infos about those XRC errors in Wikidpad can be found here:
https://groups.yahoo.com/neo/groups/wikidPad/conversations/topics/8413
https://groups.yahoo.com/neo/groups/wikidPad/conversations/messages/8666