### PR TITLE
Fix XRC error

### DIFF
--- a/WikidPad.xrc
+++ b/WikidPad.xrc
@@ -1923,7 +1923,7 @@
             <border>5</border>
           </object>
           <cols>2</cols>
-          <rows>7</rows>
+          <rows>8</rows>
           <object class="sizeritem">
             <object class="wxStaticText">
               <label>Left double click in preview:</label>


### PR DESCRIPTION
Error when trying to set options via Extra -> Options...:

XRC error: 1884: too many children in grid sizer: 16 > 2 x 7 (consider omitting the number of rows or columns)
XRC error: 1884: unexpected item in sizer

InternalError: XML-ID 'chMouseMiddleButtonWithoutCtrl' not found in <pwiki.OptionsDialog.OptionsDialog; proxy of <Swig Object of type 'wxDialog *'>>