### PR TITLE
os.stat_float_times was deprecated in Python 3.1, and removed in Python 3.7

### DIFF
--- a/WikidPadStarter.py
+++ b/WikidPadStarter.py
@@ -9,7 +9,6 @@
 
 
 import sys, os, traceback, os.path, glob, shutil, imp, warnings, configparser
-os.stat_float_times(True)
 
 if not hasattr(sys, 'frozen'):
     sys.path.insert(0, "lib")


### PR DESCRIPTION
Resolves #29.

My interpretation of the Python 3.6 docs is that this call is superflous
today anyway: "If newvalue is True, future
calls to stat() return floats ... Python now returns float values by
default." https://docs.python.org/3.6/library/os.html#os.stat_float_times