### PR TITLE
Fix: Use return to terminate generator

### DIFF
--- a/lib/pwiki/WikiTreeCtrl.py
+++ b/lib/pwiki/WikiTreeCtrl.py
@@ -1773,7 +1773,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
         try:        
             nodeObj = self.GetItemData(parentnodeid)
         except Exception:
-            raise StopIteration
+            return
 
         wikiData = self.pWiki.getWikiData()
 
@@ -1791,7 +1791,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
                     tuple(nodeObj.getNodePath()))
 
         if not self.IsExpanded(parentnodeid):
-            raise StopIteration
+            return
 
 #         if nodeObj.representsWikiWord():
 #             retObj = self.refreshExecutor.executeAsync(
@@ -1932,7 +1932,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
 
                 nodeid, cookie = self.GetNextChild(parentnodeid, cookie)
             
-        raise StopIteration
+        return
 
 
     def onRenamedWikiPage(self, miscevt):


### PR DESCRIPTION
Raising the StopIteration exception inside a generator generates a
DeprecationWarning in Python 3.6, and triggers a RuntimeError in
Python 3.7. The proper way to terminate a generator is return, not
raise StopIteration.

See:

* https://docs.python.org/3/whatsnew/3.5.html#whatsnew-pep-479

"PEP 479 changes the behavior of generators: when a StopIteration
exception is raised inside a generator, it is replaced with a
RuntimeError before it exits the generator frame."

* https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

"Deprecated Python behavior

Raising the StopIteration exception inside a generator will now
enerate a DeprecationWarning, and will trigger a RuntimeError in
Python 3.7. See PEP 479: Change StopIteration handling inside
generators for details."

* https://www.python.org/dev/peps/pep-0479/

"Finally, the proposal also clears up the confusion about how
to terminate a generator: the proper way is return, not
raise StopIteration."