### PR TITLE
replace deprecated time.clock with time.perf_counter

### DIFF
--- a/WikidPad/lib/aui/framemanager.py
+++ b/WikidPad/lib/aui/framemanager.py
@@ -4766,7 +4766,7 @@ class AuiManager(wx.EvtHandler):
         # if the pane's name identifier is blank, create a random string
         if pinfo.name == "" or already_exists:
             pinfo.name = ("%s%08x%08x%08x") % (pinfo.window.GetName(), int(time.time()),
-                                               int(time.clock()), len(self._panes))
+                                               int(time.perf_counter()), len(self._panes))
 
         # set initial proportion (if not already set)
         if pinfo.dock_proportion == 0:

--- a/WikidPad/lib/pwiki/Utilities.py
+++ b/WikidPad/lib/pwiki/Utilities.py
@@ -148,7 +148,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
         debuglog("SingleThreadExecutor starting")
         with self.dequeCondition:
             self.paused = False
-            if self.thread is not None and self.thread.isAlive():
+            if self.thread is not None and self.thread.is_alive():
                 return
 
             self.prepare()
@@ -233,7 +233,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
     def _fireStateChange(self, running=None):
         if running is None:
             # Detect self
-            running = self.thread is not None and self.thread.isAlive()
+            running = self.thread is not None and self.thread.is_alive()
 
         callInMainThreadAsync(self.fireMiscEventProps, {"changed state": True,
             "isRunning": running, "jobCount": self.getJobCount()})
@@ -377,7 +377,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
 
         If the queues are empty, executor stops in each case.
         """
-        if self.thread is None or not self.thread.isAlive():
+        if self.thread is None or not self.thread.is_alive():
             return
 
         with self.dequeCondition:
@@ -394,7 +394,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
 
         self.thread.join(120)  # TODO: Replace by constant
 
-        if self.thread.isAlive():
+        if self.thread.is_alive():
             raise DeadBlockPreventionTimeOutError()
 
         debuglog("SingleThreadExecutor ending, thread terminated",
@@ -414,7 +414,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
         with self.dequeCondition:
             thread = self.thread
             
-            if thread is None or not thread.isAlive():
+            if thread is None or not thread.is_alive():
                 return False
 
             self.paused = True
@@ -423,7 +423,7 @@ class SingleThreadExecutor(BasicThreadStop, MiscEvent.MiscEventSourceMixin):
         if wait:
             thread.join(120)  # TODO: Replace by constant
     
-            if thread.isAlive():
+            if thread.is_alive():
                 raise DeadBlockPreventionTimeOutError()
 
             self.thread = None

--- a/WikidPad/lib/pwiki/WikiPyparsing.py
+++ b/WikidPad/lib/pwiki/WikiPyparsing.py
@@ -1338,7 +1338,7 @@ class ParserElement:
                     retTokens = retTokens.asList()
 
             state.threadstop.testValidThread()
-#             print "--Clock" , time.clock()
+#             print "--Clock" , time.perf_counter()
 #             elif isinstance(retTokens, list) and len(retTokens) > 0 and self.resultsName:
 #                 retTokens = [buildSyntaxNode(tokens, tokensStart, self.resultsName)]
             return loc, retTokens
@@ -1446,7 +1446,7 @@ class ParserElement:
 #                 retTokens = retTokens.asList()
 
             state.threadstop.testValidThread()
-#             print "--Clock" , time.clock()
+#             print "--Clock" , time.perf_counter()
 #             elif isinstance(retTokens, list) and len(retTokens) > 0 and self.resultsName:
 #                 retTokens = [buildSyntaxNode(tokens, tokensStart, self.resultsName)]
             return loc, retTokens

--- a/WikidPad/lib/pwiki/WikiTreeCtrl.py
+++ b/WikidPad/lib/pwiki/WikiTreeCtrl.py
@@ -1317,7 +1317,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
 
         self.SetSpacing(0)
         self.refreshGenerator = None  # Generator called in OnIdle
-        self.refreshGeneratorLastCallTime = time.clock()  # Initial value
+        self.refreshGeneratorLastCallTime = time.perf_counter()  # Initial value
         self.refreshGeneratorLastCallMinDelay = 0.1
         self.refreshExecutor = Utilities.SingleThreadExecutor(1)
         self.refreshStartLock = False  # Disallows starting of refresh (mainly
@@ -2602,7 +2602,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
     def OnIdle(self, event):
         gen = self.refreshGenerator
         if gen is not None:
-            cl = time.clock()
+            cl = time.perf_counter()
             if cl < self.refreshGeneratorLastCallTime:
                 # May happen under special circumstances (e.g. after hibernation)
                 self.refreshGeneratorLastCallTime = cl
@@ -2614,7 +2614,7 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
                 next(gen)
                 # Set time after generator run, so time needed by generator
                 # itself doesn't count
-                self.refreshGeneratorLastCallTime = time.clock()
+                self.refreshGeneratorLastCallTime = time.perf_counter()
             except StopIteration:
                 if self.refreshGenerator == gen:
                     self.refreshGenerator = None

--- a/WikidPad/lib/pwiki/WikiTxtDialogs.py
+++ b/WikidPad/lib/pwiki/WikiTxtDialogs.py
@@ -349,7 +349,7 @@ class ImagePasteSaver:
         if self.formatNo < 1 or self.formatNo > 2:
             return None
 
-        img.SetOptionInt("quality", self.quality)
+        img.SetOption("quality", self.quality)
 
         tempFileSet = TempFileSet()
 

--- a/WikidPad/lib/whoosh/lang/morph_en.py
+++ b/WikidPad/lib/whoosh/lang/morph_en.py
@@ -935,7 +935,7 @@ def variations(word):
 
 if __name__ == '__main__':
     import time
-    t = time.clock()
+    t = time.perf_counter()
     s = variations("rendering")
-    print(time.clock() - t)
+    print(time.perf_counter() - t)
     print(len(s))

--- a/WikidPad/lib/whoosh/util/__init__.py
+++ b/WikidPad/lib/whoosh/util/__init__.py
@@ -40,7 +40,7 @@ IDCHARS = "0123456789abcdefghijklmnopqrstuvwxyz"
 if hasattr(time, "perf_counter"):
     now = time.perf_counter
 elif sys.platform == 'win32':
-    now = time.clock
+    now = time.perf_counter
 else:
     now = time.time
 


### PR DESCRIPTION
time.clock is deprecated since python3.3 and was finally removed in python3.8

This commit fixes WikidPad for python3.8

https://docs.python.org/3.4/library/time.html#time.clock
https://docs.python.org/3.8/library/time.html