### PR TITLE
wxpython4.0.7

### DIFF
--- a/WikidPad/lib/aui/auibook.py
+++ b/WikidPad/lib/aui/auibook.py
@@ -3467,8 +3467,8 @@ class AuiNotebook(wx.Panel):
         # should happen around the middle
         if tab_ctrl_count < 2:
             new_split_size = self.GetClientSize()
-            new_split_size.x /= 2
-            new_split_size.y /= 2
+            new_split_size.x = int(new_split_size.x / 2)
+            new_split_size.y = int(new_split_size.y / 2)
 
         else:
 

--- a/WikidPad/lib/aui/tabart.py
+++ b/WikidPad/lib/aui/tabart.py
@@ -472,7 +472,7 @@ class AuiDefaultTabArt:
             dc.DrawPoint(r.x+r.width-2, r.y+1)
 
             # set rectangle down a bit for gradient drawing
-            r.SetHeight(r.GetHeight()/2)
+            r.SetHeight(int(r.GetHeight()/2))
             r.x += 2
             r.width -= 2
             r.y += r.height
@@ -566,7 +566,7 @@ class AuiDefaultTabArt:
 
         draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = drawn_tab_yoff + (drawn_tab_height)/2 - (texty/2) - 1
+        ypos = int(drawn_tab_yoff + (drawn_tab_height)/2 - (texty/2) - 1)
 
         offset_focus = text_offset
         if control:
@@ -607,11 +607,11 @@ class AuiDefaultTabArt:
             shift = (agwFlags & AUI_NB_BOTTOM and [1] or [0])[0]
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
-                rect = wx.Rect(tab_x + 4, tab_y + (tab_height - bmp.GetHeight())/2 - shift,
+                rect = wx.Rect(tab_x + 4, tab_y + int((tab_height - bmp.GetHeight())/2) - shift,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - 1,
-                               tab_y + (tab_height - bmp.GetHeight())/2 - shift,
+                               tab_y + int((tab_height - bmp.GetHeight())/2) - shift,
                                close_button_width, tab_height)
 
             rect = IndentPressedBitmap(rect, close_button_state)
@@ -1307,7 +1307,7 @@ class AuiSimpleTabArt:
         # draw focus rectangle
         if page.active and wx.Window.FindFocus() == wnd and (agwFlags & AUI_NB_NO_TAB_FOCUS) == 0:
 
-            focusRect = wx.Rect(text_offset, ((tab_y + tab_height)/2 - (texty/2) + 1),
+            focusRect = wx.Rect(text_offset, ((tab_y + int(tab_height)/2 - (texty/2)) + 1),
                                 selected_textx, selected_texty)
 
             focusRect.Inflate(2, 2)

--- a/WikidPad/lib/pwiki/AdditionalDialogs.py
+++ b/WikidPad/lib/pwiki/AdditionalDialogs.py
@@ -208,13 +208,13 @@ class OpenWikiWordDialog(wx.Dialog, ModalDialogMixin):
         self.ctrls.lb.Bind(wx.EVT_CHAR, self.OnCharListBox)
         self.ctrls.lb.Bind(wx.EVT_KEY_DOWN, self.OnKeyDownListBox)
         self.Bind(wx.EVT_LISTBOX, self.OnListBox, id=ID)
-        self.Bind(wx.EVT_LISTBOX_DCLICK, self.OnOk, id=GUI_ID.lb)
+        self.Bind(wx.EVT_LISTBOX_DCLICK, self.OnOk, source=GUI_ID.lb)
         self.Bind(wx.EVT_BUTTON, self.OnOk, id=wx.ID_OK)
-        self.Bind(wx.EVT_BUTTON, self.OnCreate, id=GUI_ID.btnCreate)
-        self.Bind(wx.EVT_CHOICE, self.OnChoiceSort, id=GUI_ID.chSort)
-        self.Bind(wx.EVT_BUTTON, self.OnDelete, id=GUI_ID.btnDelete)
-        self.Bind(wx.EVT_BUTTON, self.OnNewTab, id=GUI_ID.btnNewTab)
-        self.Bind(wx.EVT_BUTTON, self.OnNewTabBackground, id=GUI_ID.btnNewTabBackground)
+        self.Bind(wx.EVT_BUTTON, self.OnCreate, source=GUI_ID.btnCreate)
+        self.Bind(wx.EVT_CHOICE, self.OnChoiceSort, source=GUI_ID.chSort)
+        self.Bind(wx.EVT_BUTTON, self.OnDelete, source=GUI_ID.btnDelete)
+        self.Bind(wx.EVT_BUTTON, self.OnNewTab, source=GUI_ID.btnNewTab)
+        self.Bind(wx.EVT_BUTTON, self.OnNewTabBackground, source=GUI_ID.btnNewTabBackground)
 
     def OnOk(self, evt):
         if self.activateSelectedWikiWords(0):

--- a/WikidPad/lib/pwiki/DocPagePresenter.py
+++ b/WikidPad/lib/pwiki/DocPagePresenter.py
@@ -376,17 +376,17 @@ class DocPagePresenter(wx.Panel, BasicDocPagePresenter, StorablePerspective):
         wx.GetApp().getMiscEvent().addListener(self)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.viewPageHistory(),
-                id=GUI_ID.CMD_PAGE_HISTORY_LIST)
+                source=GUI_ID.CMD_PAGE_HISTORY_LIST)
         self.Bind(wx.EVT_MENU, lambda evt: self.viewPageHistory(-1),
-                id=GUI_ID.CMD_PAGE_HISTORY_LIST_UP)
+                source=GUI_ID.CMD_PAGE_HISTORY_LIST_UP)
         self.Bind(wx.EVT_MENU, lambda evt: self.viewPageHistory(1),
-                id=GUI_ID.CMD_PAGE_HISTORY_LIST_DOWN)
+                source=GUI_ID.CMD_PAGE_HISTORY_LIST_DOWN)
         self.Bind(wx.EVT_MENU, lambda evt: self.pageHistory.goInHistory(-1),
-                id=GUI_ID.CMD_PAGE_HISTORY_GO_BACK)
+                source=GUI_ID.CMD_PAGE_HISTORY_GO_BACK)
         self.Bind(wx.EVT_MENU, lambda evt: self.pageHistory.goInHistory(1),
-                id=GUI_ID.CMD_PAGE_HISTORY_GO_FORWARD)
+                source=GUI_ID.CMD_PAGE_HISTORY_GO_FORWARD)
         self.Bind(wx.EVT_MENU, lambda evt: self.goUpwardFromSubpage(),
-                id=GUI_ID.CMD_PAGE_GO_UPWARD_FROM_SUBPAGE)
+                source=GUI_ID.CMD_PAGE_GO_UPWARD_FROM_SUBPAGE)
 
 
     def close(self):

--- a/WikidPad/lib/pwiki/LogWindow.py
+++ b/WikidPad/lib/pwiki/LogWindow.py
@@ -83,9 +83,9 @@ class LogWindow(wx.Panel):
         self.messages = []
         self.sizeVisible = True
         
-        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnEntryActivated, id=GUI_ID.lcEntries) 
-        self.Bind(wx.EVT_BUTTON, self.OnClearLog, id=GUI_ID.btnClearLog)
-        self.Bind(wx.EVT_BUTTON, self.OnHideLogWindow, id=GUI_ID.btnHideLogWindow)
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnEntryActivated, source=GUI_ID.lcEntries)
+        self.Bind(wx.EVT_BUTTON, self.OnClearLog, source=GUI_ID.btnClearLog)
+        self.Bind(wx.EVT_BUTTON, self.OnHideLogWindow, source=GUI_ID.btnHideLogWindow)
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
     def close(self):

--- a/WikidPad/lib/pwiki/MainAreaPanel.py
+++ b/WikidPad/lib/pwiki/MainAreaPanel.py
@@ -98,17 +98,17 @@ class MainAreaPanel(aui.AuiNotebook, MiscEventSourceMixin, StorablePerspective):
         self.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)
 
         self.Bind(wx.EVT_MENU, self.OnCloseThisTab,
-                id=GUI_ID.CMD_CLOSE_THIS_TAB)
+                source=GUI_ID.CMD_CLOSE_THIS_TAB)
         self.Bind(wx.EVT_MENU, self.OnCloseCurrentTab,
-                id=GUI_ID.CMD_CLOSE_CURRENT_TAB)
+                source=GUI_ID.CMD_CLOSE_CURRENT_TAB)
         self.Bind(wx.EVT_MENU, self.OnCmdSwitchThisEditorPreview,
-                id=GUI_ID.CMD_THIS_TAB_SHOW_SWITCH_EDITOR_PREVIEW)
+                source=GUI_ID.CMD_THIS_TAB_SHOW_SWITCH_EDITOR_PREVIEW)
         self.Bind(wx.EVT_MENU, self.OnGoTab,
-                id=GUI_ID.CMD_GO_NEXT_TAB)
+                source=GUI_ID.CMD_GO_NEXT_TAB)
         self.Bind(wx.EVT_MENU, self.OnGoTab,
-                id=GUI_ID.CMD_GO_PREVIOUS_TAB)
+                source=GUI_ID.CMD_GO_PREVIOUS_TAB)
         self.Bind(wx.EVT_MENU, self.OnCmdClipboardCopyUrlToThisWikiWord,
-                id=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_WIKIWORD)
+                source=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_WIKIWORD)
 
     def close(self):
         for p in self.getPresenters():

--- a/WikidPad/lib/pwiki/PersonalWikiFrame.py
+++ b/WikidPad/lib/pwiki/PersonalWikiFrame.py
@@ -691,7 +691,10 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
             menuID=None, updatefct=None, kind=wx.ITEM_NORMAL):
         if menuID is None:
             menuID = wx.NewId()
-            
+
+        if (isinstance(menuID,wxHelper.wxSourceId)):
+            menuID = menuID.GetId()
+
         if kind is None:
             kind = wx.ITEM_NORMAL
 
@@ -1098,7 +1101,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 self.OnTextBlockUsed)
 
         menu.AppendSeparator()
-        menu.Append(GUI_ID.CMD_REREAD_TEXT_BLOCKS,
+        menu.Append(GUI_ID.CMD_REREAD_TEXT_BLOCKS.GetId(),
                 _("Reread text blocks"),
                 _("Reread the text block file(s) and recreate menu"))
         self.Bind(wx.EVT_MENU, self.OnRereadTextBlocks,
@@ -1154,13 +1157,13 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 self.OnFavoriteWikiUsed)
 
         menu.AppendSeparator()
-        menu.Append(GUI_ID.CMD_ADD_CURRENT_WIKI_TO_FAVORITES,
+        menu.Append(GUI_ID.CMD_ADD_CURRENT_WIKI_TO_FAVORITES.GetId(),
                 _("Add wiki"),
                 _("Add a wiki to the favorites"))
         self.Bind(wx.EVT_MENU, self.OnAddToFavoriteWikis,
                 source=GUI_ID.CMD_ADD_CURRENT_WIKI_TO_FAVORITES)
 
-        menu.Append(GUI_ID.CMD_MANAGE_FAVORITE_WIKIS,
+        menu.Append(GUI_ID.CMD_MANAGE_FAVORITE_WIKIS.GetId(),
                 _("Manage favorites"),
                 _("Manage favorites"))
         self.Bind(wx.EVT_MENU, self.OnManageFavoriteWikis,
@@ -1313,11 +1316,11 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         editMenu = wx.Menu()
         
         self.addMenuItem(editMenu, _('&Undo') + '\t' + self.keyBindings.Undo,
-                _('Undo'), self._OnRoundtripEvent, menuID=GUI_ID.CMD_UNDO,
+                _('Undo'), self._OnRoundtripEvent, menuID=GUI_ID.CMD_UNDO.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
 
         self.addMenuItem(editMenu, _('&Redo') + '\t' + self.keyBindings.Redo,
-                _('Redo'), self._OnRoundtripEvent, menuID=GUI_ID.CMD_REDO,
+                _('Redo'), self._OnRoundtripEvent, menuID=GUI_ID.CMD_REDO.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
  
         editMenu.AppendSeparator()
@@ -1334,28 +1337,28 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         self.addMenuItem(editMenu, _('Cu&t') + '\t' + self.keyBindings.Cut,
                 _('Cut'), self._OnRoundtripEvent,
-                "tb_cut", menuID=GUI_ID.CMD_CLIPBOARD_CUT,
+                "tb_cut", menuID=GUI_ID.CMD_CLIPBOARD_CUT.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
 
         self.addMenuItem(editMenu, _('&Copy') + '\t' + self.keyBindings.Copy,
                 _('Copy'), self._OnRoundtripEvent,
-                "tb_copy", menuID=GUI_ID.CMD_CLIPBOARD_COPY)
+                "tb_copy", menuID=GUI_ID.CMD_CLIPBOARD_COPY.GetId())
 
         self.addMenuItem(editMenu, _('&Paste') + '\t' + self.keyBindings.Paste,
                 _('Paste'), self._OnRoundtripEvent,
-                "tb_paste", menuID=GUI_ID.CMD_CLIPBOARD_PASTE,
+                "tb_paste", menuID=GUI_ID.CMD_CLIPBOARD_PASTE.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
 
         self.addMenuItem(editMenu, _('&Paste Raw HTML') + '\t' +
                 self.keyBindings.PasteRawHtml,
                 _('Paste HTML data as is if available'), self._OnRoundtripEvent,
-                "tb_paste", menuID=GUI_ID.CMD_CLIPBOARD_PASTE_RAW_HTML,
+                "tb_paste", menuID=GUI_ID.CMD_CLIPBOARD_PASTE_RAW_HTML.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage,
                     self.OnUpdateDisNotTextedit,self.OnUpdateDisNotHtmlOnClipboard))
 
         self.addMenuItem(editMenu, _('Select &All') + '\t' + self.keyBindings.SelectAll,
                 _('Select All'), self._OnRoundtripEvent,
-                 menuID=GUI_ID.CMD_SELECT_ALL)
+                 menuID=GUI_ID.CMD_SELECT_ALL.GetId())
 
         editMenu.AppendSeparator()
 
@@ -1381,7 +1384,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                     self.keyBindings.CatchClipboardAtPage, 
                     _("Text copied to clipboard is also appended to this page"),
                     self.OnClipboardCatcherAtPage, 
-                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_AT_PAGE,
+                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_AT_PAGE.GetId(),
                     updatefct=self.OnUpdateClipboardCatcher,
                     kind=wx.ITEM_RADIO)
 
@@ -1389,7 +1392,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                     self.keyBindings.CatchClipboardAtCursor, 
                     _("Text copied to clipboard is also added to cursor position"),
                     self.OnClipboardCatcherAtCursor, 
-                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_AT_CURSOR,
+                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_AT_CURSOR.GetId(),
                     updatefct=self.OnUpdateClipboardCatcher,
                     kind=wx.ITEM_RADIO)
 
@@ -1397,7 +1400,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                     self.keyBindings.CatchClipboardOff, 
                     _("Switch off clipboard catcher"),
                     self.OnClipboardCatcherOff, 
-                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_OFF,
+                    menuID=GUI_ID.CMD_CLIPBOARD_CATCHER_OFF.GetId(),
                     updatefct=self.OnUpdateClipboardCatcher,
                     kind=wx.ITEM_RADIO)
 
@@ -1408,24 +1411,24 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         self.addMenuItem(logLineMoveMenu, _('&Up') +
                 '\t' + self.keyBindings.LogLineUp,
                 _("Move line upward"), self._OnRoundtripEvent,
-                menuID=GUI_ID.CMD_LOGICAL_LINE_UP,
+                menuID=GUI_ID.CMD_LOGICAL_LINE_UP.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
         self.addMenuItem(logLineMoveMenu, _('Up with indented') +
                 '\t' + self.keyBindings.LogLineUpWithIndented,
                 _("Move line with more indented lines below upward"),
                 self._OnRoundtripEvent,
-                menuID=GUI_ID.CMD_LOGICAL_LINE_UP_WITH_INDENT,
+                menuID=GUI_ID.CMD_LOGICAL_LINE_UP_WITH_INDENT.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
         self.addMenuItem(logLineMoveMenu, _('&Down') +
                 '\t' + self.keyBindings.LogLineDown,
                 _("Move line downward"), self._OnRoundtripEvent,
-                menuID=GUI_ID.CMD_LOGICAL_LINE_DOWN,
+                menuID=GUI_ID.CMD_LOGICAL_LINE_DOWN.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
         self.addMenuItem(logLineMoveMenu, _('Down with indented') +
                 '\t' + self.keyBindings.LogLineDownWithIndented,
                 _("Move line with more indented lines below downward"),
                 self._OnRoundtripEvent,
-                menuID=GUI_ID.CMD_LOGICAL_LINE_DOWN_WITH_INDENT,
+                menuID=GUI_ID.CMD_LOGICAL_LINE_DOWN_WITH_INDENT.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit))
 
         if SpellChecker.isSpellCheckSupported():
@@ -1521,7 +1524,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _("Show toolbar"),
                 lambda evt: self.setShowToolbar(
                 not self.getConfig().getboolean("main", "toolbar_show", True)), 
-                menuID=GUI_ID.CMD_SHOW_TOOLBAR,
+                menuID=GUI_ID.CMD_SHOW_TOOLBAR.GetId(),
                 updatefct=self.OnUpdateToolbarMenuItem,
                 kind=wx.ITEM_CHECK)
 
@@ -1575,7 +1578,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 self.keyBindings.StayOnTop, 
                 _("Stay on Top of all other windows"),
                 lambda evt: self.setStayOnTop(not self.getStayOnTop()), 
-                menuID=GUI_ID.CMD_STAY_ON_TOP,
+                menuID=GUI_ID.CMD_STAY_ON_TOP.GetId(),
                 updatefct=self.OnUpdateStayOnTopMenuItem,
                 kind=wx.ITEM_CHECK)
         
@@ -1583,11 +1586,11 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
        
         self.addMenuItem(viewMenu, _('&Zoom In') + '\t' + self.keyBindings.ZoomIn,
                 _('Zoom In'), self._OnRoundtripEvent, "tb_zoomin",
-                menuID=GUI_ID.CMD_ZOOM_IN)
+                menuID=GUI_ID.CMD_ZOOM_IN.GetId())
 
         self.addMenuItem(viewMenu, _('Zoo&m Out') + '\t' + self.keyBindings.ZoomOut,
                 _('Zoom Out'), self._OnRoundtripEvent, "tb_zoomout",
-                menuID=GUI_ID.CMD_ZOOM_OUT)
+                menuID=GUI_ID.CMD_ZOOM_OUT.GetId())
 
 
 #         menuItem = wx.MenuItem(viewMenu, GUI_ID.CMD_SHOW_TOOLBAR,
@@ -1612,18 +1615,18 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 self.keyBindings.ShowSwitchEditorPreview,
                 _('Switch between editor and preview'),
                 lambda evt: self.setDocPagePresenterSubControl(None),  "tb_switch ed prev",
-                    menuID=GUI_ID.CMD_TAB_SHOW_SWITCH_EDITOR_PREVIEW)
+                    menuID=GUI_ID.CMD_TAB_SHOW_SWITCH_EDITOR_PREVIEW.GetId())
 
         self.addMenuItem(tabsMenu, _('Enter Edit Mode') + '\t' + self.keyBindings.ShowEditor,
                 _('Show editor in tab'),
                 lambda evt: self.setDocPagePresenterSubControl("textedit"),  #  "tb_editor",
-                    menuID=GUI_ID.CMD_TAB_SHOW_EDITOR)
+                    menuID=GUI_ID.CMD_TAB_SHOW_EDITOR.GetId())
 
         self.addMenuItem(tabsMenu, _('Enter Preview Mode') + '\t' +
                 self.keyBindings.ShowPreview,
                 _('Show preview in tab'),
                 lambda evt: self.setDocPagePresenterSubControl("preview"),  #   "tb_preview",
-                    menuID=GUI_ID.CMD_TAB_SHOW_PREVIEW)
+                    menuID=GUI_ID.CMD_TAB_SHOW_PREVIEW.GetId())
 
         tabsMenu.AppendSeparator()
 
@@ -1650,20 +1653,20 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _('Save all open pages'),
                 lambda evt: (self.saveAllDocPages(),
                 self.getWikiData().commit()), "tb_save",
-                menuID=GUI_ID.CMD_SAVE_WIKI,
+                menuID=GUI_ID.CMD_SAVE_WIKI.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyWiki,))
 
         # TODO: More fine grained check for en-/disabling of rename and delete?
         self.addMenuItem(wikiPageMenu, _('&Rename') + '\t' + self.keyBindings.Rename,
                 _('Rename current wiki word'), lambda evt: self.showWikiWordRenameDialog(),
                 "tb_rename",
-                menuID=GUI_ID.CMD_RENAME_PAGE,
+                menuID=GUI_ID.CMD_RENAME_PAGE.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyWiki, self.OnUpdateDisNotWikiPage))
 
         self.addMenuItem(wikiPageMenu, _('&Delete') + '\t' + self.keyBindings.Delete,
                 _('Delete current wiki word'), lambda evt: self.showWikiWordDeleteDialog(),
                 "tb_delete",
-                menuID=GUI_ID.CMD_DELETE_PAGE,
+                menuID=GUI_ID.CMD_DELETE_PAGE.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyWiki, self.OnUpdateDisNotWikiPage))
 
         wikiPageMenu.AppendSeparator()
@@ -1738,21 +1741,21 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         self.addMenuItem(formatMenu, _('&Bold') + '\t' + self.keyBindings.Bold,
                 _('Bold'), lambda evt: self.getActiveEditor().formatSelection("bold"),
                 "tb_bold",
-                menuID=GUI_ID.CMD_FORMAT_BOLD,
+                menuID=GUI_ID.CMD_FORMAT_BOLD.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit,
                     self.OnUpdateDisNotWikiPage))
 
         self.addMenuItem(formatMenu, _('&Italic') + '\t' + self.keyBindings.Italic,
                 _('Italic'), lambda evt: self.getActiveEditor().formatSelection("italics"),
                 "tb_italic",
-                menuID=GUI_ID.CMD_FORMAT_ITALIC,
+                menuID=GUI_ID.CMD_FORMAT_ITALIC.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit,
                     self.OnUpdateDisNotWikiPage))
 
         self.addMenuItem(formatMenu, _('&Heading') + '\t' + self.keyBindings.Heading,
                 _('Add Heading'), lambda evt: self.getActiveEditor().formatSelection("plusHeading"),
                 "tb_heading",
-                menuID=GUI_ID.CMD_FORMAT_HEADING_PLUS,
+                menuID=GUI_ID.CMD_FORMAT_HEADING_PLUS.GetId(),
                 updatefct=(self.OnUpdateDisReadOnlyPage, self.OnUpdateDisNotTextedit,
                     self.OnUpdateDisNotWikiPage))
 
@@ -1802,7 +1805,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         for cmi in list(cmdIdToIconName.keys()):
             self.Bind(wx.EVT_MENU, self.OnInsertStringFromDict, id=cmi)
 
-        formatMenu.Append(GUI_ID.MENU_ADD_ICON_NAME,
+        formatMenu.Append(GUI_ID.MENU_ADD_ICON_NAME.GetId(),
                 _('&Icon Name'), iconsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
@@ -1815,7 +1818,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         for cmi in list(cmdIdToColorName.keys()):
             self.Bind(wx.EVT_MENU, self.OnInsertStringFromDict, id=cmi)
 
-        formatMenu.Append(GUI_ID.MENU_ADD_STRING_NAME,
+        formatMenu.Append(GUI_ID.MENU_ADD_STRING_NAME.GetId(),
                 _('&Color Name'), colorsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
@@ -1833,7 +1836,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         for cmi in list(self.cmdIdToIconNameForAttribute.keys()):
             self.Bind(wx.EVT_MENU, self.OnInsertIconAttribute, id=cmi)
 
-        addAttributeMenu.Append(GUI_ID.MENU_ADD_ICON_ATTRIBUTE,
+        addAttributeMenu.Append(GUI_ID.MENU_ADD_ICON_ATTRIBUTE.GetId(),
                 _('&Icon Attribute'), iconsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
@@ -1844,7 +1847,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         for cmi in list(self.cmdIdToColorNameForAttribute.keys()):
             self.Bind(wx.EVT_MENU, self.OnInsertColorAttribute, id=cmi)
 
-        addAttributeMenu.Append(GUI_ID.MENU_ADD_COLOR_ATTRIBUTE,
+        addAttributeMenu.Append(GUI_ID.MENU_ADD_COLOR_ATTRIBUTE.GetId(),
                 _('&Color Attribute'), colorsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
@@ -2097,13 +2100,13 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         icon = self.lookupSystemIcon("tb_back")
         tbID = GUI_ID.CMD_PAGE_HISTORY_GO_BACK
-        addSimpleTool(tbID, icon, _("Back") + " " + self.keyBindings.GoBack,
+        addSimpleTool(tbID.GetId(), icon, _("Back") + " " + self.keyBindings.GoBack,
                 _("Back"))
         self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
         icon = self.lookupSystemIcon("tb_forward")
         tbID = GUI_ID.CMD_PAGE_HISTORY_GO_FORWARD
-        addSimpleTool(tbID, icon, _("Forward") + " " + self.keyBindings.GoForward,
+        addSimpleTool(tbID.GetId(), icon, _("Forward") + " " + self.keyBindings.GoForward,
                 _("Forward"))
         self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
@@ -2137,25 +2140,25 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         icon = self.lookupSystemIcon("tb_up")
         tbID = GUI_ID.CMD_PAGE_GO_UPWARD_FROM_SUBPAGE
-        addSimpleTool(tbID, icon, _("Go upward from a subpage"),
+        addSimpleTool(tbID.GetId(), icon, _("Go upward from a subpage"),
                 _("Go upward from a subpage"))
         self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
         addSimpleTool(wx.NewId(), seperator, _("Separator"), _("Separator"))
 
         icon = self.lookupSystemIcon("tb_save")
-        addSimpleTool(GUI_ID.CMD_SAVE_WIKI, icon,
+        addSimpleTool(GUI_ID.CMD_SAVE_WIKI.GetId(), icon,
                 _("Save Wiki Word") + " " + self.keyBindings.Save,
                 _("Save Wiki Word"))
 
         icon = self.lookupSystemIcon("tb_rename")
-        addSimpleTool(GUI_ID.CMD_RENAME_PAGE, icon,
+        addSimpleTool(GUI_ID.CMD_RENAME_PAGE.GetId(), icon,
                 _("Rename Wiki Word") + " " + self.keyBindings.Rename,
                 _("Rename Wiki Word"))
 #         self.Bind(wx.EVT_TOOL, lambda evt: self.showWikiWordRenameDialog(), id=tbID)
 
         icon = self.lookupSystemIcon("tb_delete")
-        addSimpleTool(GUI_ID.CMD_DELETE_PAGE, icon,
+        addSimpleTool(GUI_ID.CMD_DELETE_PAGE.GetId(), icon,
                 _("Delete Wiki Word") + " " + self.keyBindings.Delete,
                 _("Delete Wiki Word"))
 #         self.Bind(wx.EVT_TOOL, lambda evt: self.showWikiWordDeleteDialog(), id=tbID)
@@ -2163,19 +2166,19 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         addSimpleTool(wx.NewId(), seperator, _("Separator"), _("Separator"))
 
         icon = self.lookupSystemIcon("tb_heading")
-        addSimpleTool(GUI_ID.CMD_FORMAT_HEADING_PLUS, icon,
+        addSimpleTool(GUI_ID.CMD_FORMAT_HEADING_PLUS.GetId(), icon,
                 _("Heading") + " " + self.keyBindings.Heading, _("Heading"))
 #         wx.EVT_TOOL(self, tbID, lambda evt: self.keyBindings.addHeading(
 #                 self.getActiveEditor()))
 
         icon = self.lookupSystemIcon("tb_bold")
-        addSimpleTool(GUI_ID.CMD_FORMAT_BOLD, icon,
+        addSimpleTool(GUI_ID.CMD_FORMAT_BOLD.GetId(), icon,
                 _("Bold") + " " + self.keyBindings.Bold, _("Bold"))
 #         wx.EVT_TOOL(self, tbID, lambda evt: self.keyBindings.makeBold(
 #                 self.getActiveEditor()))
 
         icon = self.lookupSystemIcon("tb_italic")
-        addSimpleTool(GUI_ID.CMD_FORMAT_ITALIC, icon,
+        addSimpleTool(GUI_ID.CMD_FORMAT_ITALIC.GetId(), icon,
                 _("Italic") + " " + self.keyBindings.Italic, _("Italic"))
 #         wx.EVT_TOOL(self, tbID, lambda evt: self.keyBindings.makeItalic(
 #                 self.getActiveEditor()))
@@ -2184,27 +2187,27 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         icon = self.lookupSystemIcon("tb_switch ed prev")
         tbID = GUI_ID.CMD_TAB_SHOW_SWITCH_EDITOR_PREVIEW
-        addSimpleTool(tbID, icon, _("Switch Editor/Preview"),
+        addSimpleTool(tbID.GetId(), icon, _("Switch Editor/Preview"),
                 _("Switch between editor and preview"))
 
         icon = self.lookupSystemIcon("tb_zoomin")
         tbID = GUI_ID.CMD_ZOOM_IN
-        addSimpleTool(tbID, icon, _("Zoom In"), _("Zoom In"))
+        addSimpleTool(tbID.GetId(), icon, _("Zoom In"), _("Zoom In"))
         self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, source=tbID)
 
         icon = self.lookupSystemIcon("tb_zoomout")
         tbID = GUI_ID.CMD_ZOOM_OUT
-        addSimpleTool(tbID, icon, _("Zoom Out"), _("Zoom Out"))
+        addSimpleTool(tbID.GetId(), icon, _("Zoom Out"), _("Zoom Out"))
         self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, source=tbID)
 
 
-        self.fastSearchField = wx.TextCtrl(tb, GUI_ID.TF_FASTSEARCH,
+        self.fastSearchField = wx.TextCtrl(tb, GUI_ID.TF_FASTSEARCH.GetId(),
                 style=wx.TE_PROCESS_ENTER | wx.TE_RICH)
         tb.AddControl(self.fastSearchField)
         self.fastSearchField.Bind(wx.EVT_KEY_DOWN, self.OnFastSearchKeyDown)
 
         icon = self.lookupSystemIcon("tb_wikize")
-        addSimpleTool(GUI_ID.CMD_FORMAT_WIKIZE_SELECTED, icon,
+        addSimpleTool(GUI_ID.CMD_FORMAT_WIKIZE_SELECTED.GetId(), icon,
                 _("Wikize Selected Word ") + self.keyBindings.MakeWikiWord,
                 _("Wikize Selected Word"))
 #         self.Bind(wx.EVT_TOOL, lambda evt: self.keyBindings.makeWikiWord(self.getActiveEditor()), id=tbID)
@@ -2589,7 +2592,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
             self.hotKeyDummyWindow.Destroy()
 
         self.hotKeyDummyWindow = wxHelper.DummyWindow(self,
-                id=GUI_ID.WND_HOTKEY_DUMMY)
+                id=GUI_ID.WND_HOTKEY_DUMMY.GetId())
         if self.configuration.getboolean("main",
                 "hotKey_showHide_byApp_isActive"):
             wxHelper.setHotKeyByString(self.hotKeyDummyWindow,

--- a/WikidPad/lib/pwiki/PersonalWikiFrame.py
+++ b/WikidPad/lib/pwiki/PersonalWikiFrame.py
@@ -1840,7 +1840,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _('&Icon Attribute'), iconsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
-                id=GUI_ID.MENU_ADD_ICON_ATTRIBUTE)
+                source=GUI_ID.MENU_ADD_ICON_ATTRIBUTE)
 
         # Build submenu for color attributes
         colorsMenu, self.cmdIdToColorNameForAttribute = AttributeHandling.buildColorsSubmenu()

--- a/WikidPad/lib/pwiki/PersonalWikiFrame.py
+++ b/WikidPad/lib/pwiki/PersonalWikiFrame.py
@@ -2307,6 +2307,10 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         self.Bind(wx.EVT_MENU, self.OnSwitchFocus, source=GUI_ID.CMD_SWITCH_FOCUS)
 
         # Table with additional possible accelerators
+        # accelerators are keyboard shortcuts linked to menu or button commands in window
+        # for each window https://docs.wxpython.org/wx.Window.html#wx.Window.SetAcceleratorTable
+        # set a table https://docs.wxpython.org/wx.AcceleratorTable.html
+        # mode of entries https://docs.wxpython.org/wx.AcceleratorEntry.html
         ADD_ACCS = (
                 ("CloseCurrentTab", GUI_ID.CMD_CLOSE_CURRENT_TAB),
                 ("SwitchFocus", GUI_ID.CMD_SWITCH_FOCUS),
@@ -2319,9 +2323,9 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         # Add alternative accelerators for clipboard operations
         accs = [
-                (wx.ACCEL_CTRL, wx.WXK_INSERT, GUI_ID.CMD_CLIPBOARD_COPY),
-                (wx.ACCEL_SHIFT, wx.WXK_INSERT, GUI_ID.CMD_CLIPBOARD_PASTE),
-                (wx.ACCEL_SHIFT, wx.WXK_DELETE, GUI_ID.CMD_CLIPBOARD_CUT)
+                (wx.ACCEL_CTRL, wx.WXK_INSERT, GUI_ID.CMD_CLIPBOARD_COPY.GetId()),
+                (wx.ACCEL_SHIFT, wx.WXK_INSERT, GUI_ID.CMD_CLIPBOARD_PASTE.GetId()),
+                (wx.ACCEL_SHIFT, wx.WXK_DELETE, GUI_ID.CMD_CLIPBOARD_CUT.GetId())
                 ]
 
 
@@ -2329,12 +2333,12 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         for keyName, menuId in ADD_ACCS:
             accP = self.keyBindings.getAccelPair(keyName)
             if accP != (None, None):
-                accs.append((accP[0], accP[1], menuId))
+                accs.append((accP[0], accP[1], menuId.GetId()))
 
         if SystemInfo.isLinux():   # Actually if wxGTK
-            accs += [(wx.ACCEL_NORMAL, fkey, GUI_ID.SPECIAL_EAT_KEY)
+            accs += [(wx.ACCEL_NORMAL, fkey, GUI_ID.SPECIAL_EAT_KEY.GetId())
                     for fkey in range(wx.WXK_F1, wx.WXK_F24 + 1)] + \
-                    [(wx.ACCEL_SHIFT, fkey, GUI_ID.SPECIAL_EAT_KEY)
+                    [(wx.ACCEL_SHIFT, fkey, GUI_ID.SPECIAL_EAT_KEY.GetId())
                     for fkey in range(wx.WXK_F1, wx.WXK_F24 + 1)]
     
             self.Bind(wx.EVT_MENU, lambda evt: None, source=GUI_ID.SPECIAL_EAT_KEY)

--- a/WikidPad/lib/pwiki/PersonalWikiFrame.py
+++ b/WikidPad/lib/pwiki/PersonalWikiFrame.py
@@ -1102,7 +1102,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _("Reread text blocks"),
                 _("Reread the text block file(s) and recreate menu"))
         self.Bind(wx.EVT_MENU, self.OnRereadTextBlocks,
-                id=GUI_ID.CMD_REREAD_TEXT_BLOCKS)
+                source=GUI_ID.CMD_REREAD_TEXT_BLOCKS)
 
 
     def OnTextBlockUsed(self, evt):
@@ -1158,13 +1158,13 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _("Add wiki"),
                 _("Add a wiki to the favorites"))
         self.Bind(wx.EVT_MENU, self.OnAddToFavoriteWikis,
-                id=GUI_ID.CMD_ADD_CURRENT_WIKI_TO_FAVORITES)
+                source=GUI_ID.CMD_ADD_CURRENT_WIKI_TO_FAVORITES)
 
         menu.Append(GUI_ID.CMD_MANAGE_FAVORITE_WIKIS,
                 _("Manage favorites"),
                 _("Manage favorites"))
         self.Bind(wx.EVT_MENU, self.OnManageFavoriteWikis,
-                id=GUI_ID.CMD_MANAGE_FAVORITE_WIKIS)
+                source=GUI_ID.CMD_MANAGE_FAVORITE_WIKIS)
 
 
     def OnFavoriteWikiUsed(self, evt):
@@ -1370,7 +1370,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         editMenu.AppendSubMenu(self.textBlocksMenu, _('Paste T&extblock'))
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
-                id=GUI_ID.MENU_TEXT_BLOCKS)
+                source=GUI_ID.MENU_TEXT_BLOCKS)
 
 
         if self.clipboardInterceptor is not None:
@@ -1630,17 +1630,17 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         wxHelper.appendToMenuByMenuDesc(tabsMenu, FOLD_MENU, self.keyBindings)
 
         self.Bind(wx.EVT_MENU, self.OnCmdCheckShowFolding,
-                id=GUI_ID.CMD_CHECKBOX_SHOW_FOLDING)
+                source=GUI_ID.CMD_CHECKBOX_SHOW_FOLDING)
         self.Bind(wx.EVT_UPDATE_UI, self.OnUpdateShowFolding,
-                id=GUI_ID.CMD_CHECKBOX_SHOW_FOLDING)
+                source=GUI_ID.CMD_CHECKBOX_SHOW_FOLDING)
 
         self.Bind(wx.EVT_MENU,
                 lambda evt: self.getActiveEditor().toggleCurrentFolding(),
-                id=GUI_ID.CMD_TOGGLE_CURRENT_FOLDING)
+                source=GUI_ID.CMD_TOGGLE_CURRENT_FOLDING)
         self.Bind(wx.EVT_MENU, lambda evt: self.getActiveEditor().unfoldAll(),
-                id=GUI_ID.CMD_UNFOLD_ALL_IN_CURRENT)
+                source=GUI_ID.CMD_UNFOLD_ALL_IN_CURRENT)
         self.Bind(wx.EVT_MENU, lambda evt: self.getActiveEditor().foldAll(),
-                id=GUI_ID.CMD_FOLD_ALL_IN_CURRENT)
+                source=GUI_ID.CMD_FOLD_ALL_IN_CURRENT)
         
 
 
@@ -1806,7 +1806,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _('&Icon Name'), iconsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
-                id=GUI_ID.MENU_ADD_ICON_NAME)
+                source=GUI_ID.MENU_ADD_ICON_NAME)
 
         self.cmdIdToInsertString = cmdIdToIconName
         
@@ -1819,7 +1819,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _('&Color Name'), colorsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
-                id=GUI_ID.MENU_ADD_STRING_NAME)
+                source=GUI_ID.MENU_ADD_STRING_NAME)
 
         self.cmdIdToInsertString.update(cmdIdToColorName)
 
@@ -1848,7 +1848,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                 _('&Color Attribute'), colorsMenu)
         self.Bind(wx.EVT_UPDATE_UI,
                 buildChainedUpdateEventFct(self.OnUpdateDisReadOnlyPage),
-                id=GUI_ID.MENU_ADD_COLOR_ATTRIBUTE)
+                source=GUI_ID.MENU_ADD_COLOR_ATTRIBUTE)
 
         # TODO: Bold attribute
 
@@ -2099,13 +2099,13 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         tbID = GUI_ID.CMD_PAGE_HISTORY_GO_BACK
         addSimpleTool(tbID, icon, _("Back") + " " + self.keyBindings.GoBack,
                 _("Back"))
-        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, id=tbID)
+        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
         icon = self.lookupSystemIcon("tb_forward")
         tbID = GUI_ID.CMD_PAGE_HISTORY_GO_FORWARD
         addSimpleTool(tbID, icon, _("Forward") + " " + self.keyBindings.GoForward,
                 _("Forward"))
-        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, id=tbID)
+        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
         icon = self.lookupSystemIcon("tb_home")
         tbID = wx.NewId()
@@ -2139,7 +2139,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         tbID = GUI_ID.CMD_PAGE_GO_UPWARD_FROM_SUBPAGE
         addSimpleTool(tbID, icon, _("Go upward from a subpage"),
                 _("Go upward from a subpage"))
-        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, id=tbID)
+        self.Bind(wx.EVT_TOOL, self._OnEventToCurrentDocPPresenter, source=tbID)
 
         addSimpleTool(wx.NewId(), seperator, _("Separator"), _("Separator"))
 
@@ -2190,12 +2190,12 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         icon = self.lookupSystemIcon("tb_zoomin")
         tbID = GUI_ID.CMD_ZOOM_IN
         addSimpleTool(tbID, icon, _("Zoom In"), _("Zoom In"))
-        self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, id=tbID)
+        self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, source=tbID)
 
         icon = self.lookupSystemIcon("tb_zoomout")
         tbID = GUI_ID.CMD_ZOOM_OUT
         addSimpleTool(tbID, icon, _("Zoom Out"), _("Zoom Out"))
-        self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, id=tbID)
+        self.Bind(wx.EVT_TOOL, self._OnRoundtripEvent, source=tbID)
 
 
         self.fastSearchField = wx.TextCtrl(tb, GUI_ID.TF_FASTSEARCH,
@@ -2301,7 +2301,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         if self.getConfig().getboolean("main", "toolbar_show", True):
             self.setShowToolbar(True)
 
-        self.Bind(wx.EVT_MENU, self.OnSwitchFocus, id=GUI_ID.CMD_SWITCH_FOCUS)
+        self.Bind(wx.EVT_MENU, self.OnSwitchFocus, source=GUI_ID.CMD_SWITCH_FOCUS)
 
         # Table with additional possible accelerators
         ADD_ACCS = (
@@ -2334,7 +2334,7 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
                     [(wx.ACCEL_SHIFT, fkey, GUI_ID.SPECIAL_EAT_KEY)
                     for fkey in range(wx.WXK_F1, wx.WXK_F24 + 1)]
     
-            self.Bind(wx.EVT_MENU, lambda evt: None, id=GUI_ID.SPECIAL_EAT_KEY)
+            self.Bind(wx.EVT_MENU, lambda evt: None, source=GUI_ID.SPECIAL_EAT_KEY)
 
         self.SetAcceleratorTable(wx.AcceleratorTable(accs))
 
@@ -2375,10 +2375,10 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
         self.Bind(wx.EVT_ICONIZE, self.OnIconize)
         self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
         
-        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, id=GUI_ID.CMD_CLOSE_CURRENT_TAB)
-        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, id=GUI_ID.CMD_GO_NEXT_TAB)
-        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, id=GUI_ID.CMD_GO_PREVIOUS_TAB)
-        self.Bind(wx.EVT_MENU, self.OnCmdFocusFastSearchField, id=GUI_ID.CMD_FOCUS_FAST_SEARCH_FIELD)
+        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, source=GUI_ID.CMD_CLOSE_CURRENT_TAB)
+        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, source=GUI_ID.CMD_GO_NEXT_TAB)
+        self.Bind(wx.EVT_MENU, self._OnRoundtripEvent, source=GUI_ID.CMD_GO_PREVIOUS_TAB)
+        self.Bind(wx.EVT_MENU, self.OnCmdFocusFastSearchField, source=GUI_ID.CMD_FOCUS_FAST_SEARCH_FIELD)
 
 
     def OnUpdateTreeCtrlMenuItem(self, evt):

--- a/WikidPad/lib/pwiki/ViHelper.py
+++ b/WikidPad/lib/pwiki/ViHelper.py
@@ -2684,7 +2684,7 @@ class ViInputDialog(wx.Panel):
 
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
-        self.run_cmd_timer = wx.Timer(self, GUI_ID.TIMER_VI_UPDATE_CMD)
+        self.run_cmd_timer = wx.Timer(self, GUI_ID.TIMER_VI_UPDATE_CMD.GetId())
         #wx.EVT_TIMER(self, GUI_ID.TIMER_VI_UPDATE_CMD, self.CheckViInput)
         self.Bind(wx.EVT_TIMER, self.CheckViInput, 
                 source=GUI_ID.TIMER_VI_UPDATE_CMD)

--- a/WikidPad/lib/pwiki/ViHelper.py
+++ b/WikidPad/lib/pwiki/ViHelper.py
@@ -2687,7 +2687,7 @@ class ViInputDialog(wx.Panel):
         self.run_cmd_timer = wx.Timer(self, GUI_ID.TIMER_VI_UPDATE_CMD)
         #wx.EVT_TIMER(self, GUI_ID.TIMER_VI_UPDATE_CMD, self.CheckViInput)
         self.Bind(wx.EVT_TIMER, self.CheckViInput, 
-                id=GUI_ID.TIMER_VI_UPDATE_CMD)
+                source=GUI_ID.TIMER_VI_UPDATE_CMD)
 
         self.ctrls.viInputTextField.SetBackgroundColour(
                 ViInputDialog.COLOR_YELLOW)
@@ -2696,14 +2696,14 @@ class ViInputDialog(wx.Panel):
 
         #wx.EVT_SET_FOCUS(self.ctrls.viInputListBox, self.FocusInputField)
 
-        self.Bind(wx.EVT_TEXT, self.OnText, id=GUI_ID.viInputTextField)
+        self.Bind(wx.EVT_TEXT, self.OnText, source=GUI_ID.viInputTextField)
         self.ctrls.viInputTextField.Bind(wx.EVT_KEY_DOWN, self.OnKeyDownInput)
 
         #wx.EVT_TIMER(self, GUI_ID.TIMER_INC_SEARCH_CLOSE,
         #        self.OnTimerIncViInputClose)
         if self.closeDelay:
             self.Bind(wx.EVT_TIMER, self.OnTimerIncViInputClose,
-                    id=GUI_ID.TIMER_INC_SEARCH_CLOSE)
+                    source=GUI_ID.TIMER_INC_SEARCH_CLOSE)
 
         self.ctrls.viInputTextField.Bind(wx.EVT_MOUSE_EVENTS, self.OnMouseAnyInput)
 

--- a/WikidPad/lib/pwiki/WikiHtmlView.py
+++ b/WikidPad/lib/pwiki/WikiHtmlView.py
@@ -155,20 +155,20 @@ class WikiHtmlView(wx.html.HtmlWindow):
         self.Bind(wx.EVT_KEY_UP, self.OnKeyUp)
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
-        self.Bind(wx.EVT_MENU, self.OnClipboardCopy, id=GUI_ID.CMD_CLIPBOARD_COPY)
-        self.Bind(wx.EVT_MENU, lambda evt: self.SelectAll(), id=GUI_ID.CMD_SELECT_ALL)
-        self.Bind(wx.EVT_MENU, lambda evt: self.addZoom(1), id=GUI_ID.CMD_ZOOM_IN)
-        self.Bind(wx.EVT_MENU, lambda evt: self.addZoom(-1), id=GUI_ID.CMD_ZOOM_OUT)
-        self.Bind(wx.EVT_MENU, self.OnActivateThis, id=GUI_ID.CMD_ACTIVATE_THIS)        
+        self.Bind(wx.EVT_MENU, self.OnClipboardCopy, source=GUI_ID.CMD_CLIPBOARD_COPY)
+        self.Bind(wx.EVT_MENU, lambda evt: self.SelectAll(), source=GUI_ID.CMD_SELECT_ALL)
+        self.Bind(wx.EVT_MENU, lambda evt: self.addZoom(1), source=GUI_ID.CMD_ZOOM_IN)
+        self.Bind(wx.EVT_MENU, lambda evt: self.addZoom(-1), source=GUI_ID.CMD_ZOOM_OUT)
+        self.Bind(wx.EVT_MENU, self.OnActivateThis, source=GUI_ID.CMD_ACTIVATE_THIS)
         self.Bind(wx.EVT_MENU, self.OnActivateNewTabThis,
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
         self.Bind(wx.EVT_MENU, self.OnActivateNewTabBackgroundThis,
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS)
         self.Bind(wx.EVT_MENU, self.OnActivateNewWindowThis,
-                id=GUI_ID.CMD_ACTIVATE_NEW_WINDOW_THIS)
+                source=GUI_ID.CMD_ACTIVATE_NEW_WINDOW_THIS)
 
         self.Bind(wx.EVT_MENU, self.OnOpenContainingFolderThis,
-                id=GUI_ID.CMD_OPEN_CONTAINING_FOLDER_THIS)
+                source=GUI_ID.CMD_OPEN_CONTAINING_FOLDER_THIS)
 
         self.Bind(wx.EVT_SET_FOCUS, self.OnSetFocus)
         self.Bind(wx.EVT_LEFT_DCLICK, self.OnLeftDClick)

--- a/WikidPad/lib/pwiki/WikiTreeCtrl.py
+++ b/WikidPad/lib/pwiki/WikiTreeCtrl.py
@@ -1384,25 +1384,25 @@ class WikiTreeCtrl(customtreectrl.CustomTreeCtrl):          # wxTreeCtrl):
         # TODO Let PersonalWikiFrame handle this 
         self.Bind(wx.EVT_MENU, lambda evt: self.pWiki.showWikiWordRenameDialog(
                 self.GetItemData(self.contextMenuNode).getWikiWord()),
-                id=GUI_ID.CMD_RENAME_THIS_WIKIWORD)
+                source=GUI_ID.CMD_RENAME_THIS_WIKIWORD)
         self.Bind(wx.EVT_MENU, lambda evt: self.pWiki.showWikiWordDeleteDialog(
                 self.GetItemData(self.contextMenuNode).getWikiWord()),
-                id=GUI_ID.CMD_DELETE_THIS_WIKIWORD)
+                source=GUI_ID.CMD_DELETE_THIS_WIKIWORD)
         self.Bind(wx.EVT_MENU, lambda evt: self.pWiki.insertAttribute(
                 "bookmarked", "true",
                 self.GetItemData(self.contextMenuNode).getWikiWord()),
-                id=GUI_ID.CMD_BOOKMARK_THIS_WIKIWORD)
+                source=GUI_ID.CMD_BOOKMARK_THIS_WIKIWORD)
         self.Bind(wx.EVT_MENU, lambda evt: self.pWiki.setWikiWordAsRoot(
                 self.GetItemData(self.contextMenuNode).getWikiWord()),
-                id=GUI_ID.CMD_SETASROOT_THIS_WIKIWORD)
+                source=GUI_ID.CMD_SETASROOT_THIS_WIKIWORD)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.collapseAll(),
-                id=GUI_ID.CMD_COLLAPSE_TREE)
+                source=GUI_ID.CMD_COLLAPSE_TREE)
 
-        self.Bind(wx.EVT_MENU, self.OnAppendWikiWord, id=GUI_ID.CMD_APPEND_WIKIWORD_FOR_THIS)
-        self.Bind(wx.EVT_MENU, self.OnPrependWikiWord, id=GUI_ID.CMD_PREPEND_WIKIWORD_FOR_THIS)
-        self.Bind(wx.EVT_MENU, self.OnActivateNewTabThis, id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
-        self.Bind(wx.EVT_MENU, self.OnCmdClipboardCopyUrlToThisWikiWord, id=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_WIKIWORD)
+        self.Bind(wx.EVT_MENU, self.OnAppendWikiWord, source=GUI_ID.CMD_APPEND_WIKIWORD_FOR_THIS)
+        self.Bind(wx.EVT_MENU, self.OnPrependWikiWord, source=GUI_ID.CMD_PREPEND_WIKIWORD_FOR_THIS)
+        self.Bind(wx.EVT_MENU, self.OnActivateNewTabThis, source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
+        self.Bind(wx.EVT_MENU, self.OnCmdClipboardCopyUrlToThisWikiWord, source=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_WIKIWORD)
                 
 
 

--- a/WikidPad/lib/pwiki/WikiTxtCtrl.py
+++ b/WikidPad/lib/pwiki/WikiTxtCtrl.py
@@ -307,96 +307,96 @@ class WikiTxtCtrl(SearchableScintillaControl):
         self.contextMenuSpellCheckSuggestions = None
 
         # Connect context menu events to functions
-        self.Bind(wx.EVT_MENU, lambda evt: self.Undo(), id=GUI_ID.CMD_UNDO)
-        self.Bind(wx.EVT_MENU, lambda evt: self.Redo(), id=GUI_ID.CMD_REDO)
+        self.Bind(wx.EVT_MENU, lambda evt: self.Undo(), source=GUI_ID.CMD_UNDO)
+        self.Bind(wx.EVT_MENU, lambda evt: self.Redo(), source=GUI_ID.CMD_REDO)
 
-        self.Bind(wx.EVT_MENU, lambda evt: self.Cut(), id=GUI_ID.CMD_CLIPBOARD_CUT)
-        self.Bind(wx.EVT_MENU, lambda evt: self.Copy(), id=GUI_ID.CMD_CLIPBOARD_COPY)
-        self.Bind(wx.EVT_MENU, lambda evt: self.Paste(), id=GUI_ID.CMD_CLIPBOARD_PASTE)
-        self.Bind(wx.EVT_MENU, lambda evt: self.pasteRawHtml(), id=GUI_ID.CMD_CLIPBOARD_PASTE_RAW_HTML)
-        self.Bind(wx.EVT_MENU, lambda evt: self.SelectAll(), id=GUI_ID.CMD_SELECT_ALL)
+        self.Bind(wx.EVT_MENU, lambda evt: self.Cut(), source=GUI_ID.CMD_CLIPBOARD_CUT)
+        self.Bind(wx.EVT_MENU, lambda evt: self.Copy(), source=GUI_ID.CMD_CLIPBOARD_COPY)
+        self.Bind(wx.EVT_MENU, lambda evt: self.Paste(), source=GUI_ID.CMD_CLIPBOARD_PASTE)
+        self.Bind(wx.EVT_MENU, lambda evt: self.pasteRawHtml(), source=GUI_ID.CMD_CLIPBOARD_PASTE_RAW_HTML)
+        self.Bind(wx.EVT_MENU, lambda evt: self.SelectAll(), source=GUI_ID.CMD_SELECT_ALL)
 
-        self.Bind(wx.EVT_MENU, lambda evt: self.ReplaceSelection(""), id=GUI_ID.CMD_TEXT_DELETE)
-        self.Bind(wx.EVT_MENU, lambda evt: self.CmdKeyExecute(wx.stc.STC_CMD_ZOOMIN), id=GUI_ID.CMD_ZOOM_IN)
-        self.Bind(wx.EVT_MENU, lambda evt: self.CmdKeyExecute(wx.stc.STC_CMD_ZOOMOUT), id=GUI_ID.CMD_ZOOM_OUT)
+        self.Bind(wx.EVT_MENU, lambda evt: self.ReplaceSelection(""), source=GUI_ID.CMD_TEXT_DELETE)
+        self.Bind(wx.EVT_MENU, lambda evt: self.CmdKeyExecute(wx.stc.STC_CMD_ZOOMIN), source=GUI_ID.CMD_ZOOM_IN)
+        self.Bind(wx.EVT_MENU, lambda evt: self.CmdKeyExecute(wx.stc.STC_CMD_ZOOMOUT), source=GUI_ID.CMD_ZOOM_OUT)
 
 
         for sps in self.SUGGESTION_CMD_IDS:
-            self.Bind(wx.EVT_MENU, self.OnReplaceThisSpellingWithSuggestion, id=sps)
+            self.Bind(wx.EVT_MENU, self.OnReplaceThisSpellingWithSuggestion, source=sps)
 
-        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreSession, id=GUI_ID.CMD_ADD_THIS_SPELLING_SESSION)
-        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreGlobal, id=GUI_ID.CMD_ADD_THIS_SPELLING_GLOBAL)
-        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreLocal, id=GUI_ID.CMD_ADD_THIS_SPELLING_LOCAL)
+        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreSession, source=GUI_ID.CMD_ADD_THIS_SPELLING_SESSION)
+        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreGlobal, source=GUI_ID.CMD_ADD_THIS_SPELLING_GLOBAL)
+        self.Bind(wx.EVT_MENU, self.OnAddThisSpellingToIgnoreLocal, source=GUI_ID.CMD_ADD_THIS_SPELLING_LOCAL)
 
-        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, id=GUI_ID.CMD_LOGICAL_LINE_UP)
-        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, id=GUI_ID.CMD_LOGICAL_LINE_UP_WITH_INDENT)
-        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, id=GUI_ID.CMD_LOGICAL_LINE_DOWN)
-        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, id=GUI_ID.CMD_LOGICAL_LINE_DOWN_WITH_INDENT)
+        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, source=GUI_ID.CMD_LOGICAL_LINE_UP)
+        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, source=GUI_ID.CMD_LOGICAL_LINE_UP_WITH_INDENT)
+        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, source=GUI_ID.CMD_LOGICAL_LINE_DOWN)
+        self.Bind(wx.EVT_MENU, self.OnLogicalLineMove, source=GUI_ID.CMD_LOGICAL_LINE_DOWN_WITH_INDENT)
 
-        self.Bind(wx.EVT_MENU, self.OnActivateThis, id=GUI_ID.CMD_ACTIVATE_THIS)
-        self.Bind(wx.EVT_MENU, self.OnActivateNewTabThis, id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
-        self.Bind(wx.EVT_MENU, self.OnActivateNewTabBackgroundThis, id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS)
-        self.Bind(wx.EVT_MENU, self.OnActivateNewWindowThis, id=GUI_ID.CMD_ACTIVATE_NEW_WINDOW_THIS)
+        self.Bind(wx.EVT_MENU, self.OnActivateThis, source=GUI_ID.CMD_ACTIVATE_THIS)
+        self.Bind(wx.EVT_MENU, self.OnActivateNewTabThis, source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS)
+        self.Bind(wx.EVT_MENU, self.OnActivateNewTabBackgroundThis, source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS)
+        self.Bind(wx.EVT_MENU, self.OnActivateNewWindowThis, source=GUI_ID.CMD_ACTIVATE_NEW_WINDOW_THIS)
 
         # Passing the evt here is not strictly necessary, but it may be
         # used in the future
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "left"),
-                id=GUI_ID.CMD_ACTIVATE_THIS_LEFT)
+                source=GUI_ID.CMD_ACTIVATE_THIS_LEFT)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "left"),
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_LEFT)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_LEFT)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(
-                evt, "left"), id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_LEFT)
+                evt, "left"), source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_LEFT)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "right"),
-                id=GUI_ID.CMD_ACTIVATE_THIS_RIGHT)
+                source=GUI_ID.CMD_ACTIVATE_THIS_RIGHT)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "right"),
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_RIGHT)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_RIGHT)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(
-                evt, "right"), id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_RIGHT)
+                evt, "right"), source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_RIGHT)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "above"),
-                id=GUI_ID.CMD_ACTIVATE_THIS_ABOVE)
+                source=GUI_ID.CMD_ACTIVATE_THIS_ABOVE)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "above"),
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_ABOVE)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_ABOVE)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(
-                evt, "above"), id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_ABOVE)
+                evt, "above"), source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_ABOVE)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "below"),
-                id=GUI_ID.CMD_ACTIVATE_THIS_BELOW)
+                source=GUI_ID.CMD_ACTIVATE_THIS_BELOW)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "below"),
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_BELOW)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_BELOW)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(
-                evt, "below"), id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_BELOW)
+                evt, "below"), source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_BELOW)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "above"), 
-                id=GUI_ID.CMD_ACTIVATE_THIS_ABOVE)
+                source=GUI_ID.CMD_ACTIVATE_THIS_ABOVE)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "above"), 
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_ABOVE)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_ABOVE)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(evt, "above"), 
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_ABOVE)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_ABOVE)
 
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateThis(evt, "below"), 
-                id=GUI_ID.CMD_ACTIVATE_THIS_BELOW)
+                source=GUI_ID.CMD_ACTIVATE_THIS_BELOW)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabThis(evt, "below"), 
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_BELOW)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_BELOW)
         self.Bind(wx.EVT_MENU, lambda evt: self.OnActivateNewTabBackgroundThis(evt, "below"), 
-                id=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_BELOW)
+                source=GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_BELOW)
 
 
         self.Bind(wx.EVT_MENU, self.OnConvertUrlAbsoluteRelativeThis, 
-                id=GUI_ID.CMD_CONVERT_URL_ABSOLUTE_RELATIVE_THIS)
+                source=GUI_ID.CMD_CONVERT_URL_ABSOLUTE_RELATIVE_THIS)
 
         self.Bind(wx.EVT_MENU, self.OnOpenContainingFolderThis, 
-                id=GUI_ID.CMD_OPEN_CONTAINING_FOLDER_THIS)
+                source=GUI_ID.CMD_OPEN_CONTAINING_FOLDER_THIS)
 
-        self.Bind(wx.EVT_MENU, self.OnDeleteFile, id=GUI_ID.CMD_DELETE_FILE)
+        self.Bind(wx.EVT_MENU, self.OnDeleteFile, source=GUI_ID.CMD_DELETE_FILE)
 
-        self.Bind(wx.EVT_MENU, self.OnRenameFile, id=GUI_ID.CMD_RENAME_FILE)
+        self.Bind(wx.EVT_MENU, self.OnRenameFile, source=GUI_ID.CMD_RENAME_FILE)
 
         self.Bind(wx.EVT_MENU, self.OnClipboardCopyUrlToThisAnchor,
-                id=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_ANCHOR)
+                source=GUI_ID.CMD_CLIPBOARD_COPY_URL_TO_THIS_ANCHOR)
 
-        self.Bind(wx.EVT_MENU, self.OnSelectTemplate, id=GUI_ID.CMD_SELECT_TEMPLATE)
+        self.Bind(wx.EVT_MENU, self.OnSelectTemplate, source=GUI_ID.CMD_SELECT_TEMPLATE)
 
     # 2.8 does not support SetEditable - Define a dummy function for now
     if wx.version().startswith("2.8"):

--- a/WikidPad/lib/pwiki/customtreectrl.py
+++ b/WikidPad/lib/pwiki/customtreectrl.py
@@ -4269,7 +4269,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             x += _PIXELS_PER_UNIT + 2 # one more scrollbar unit + 2 pixels
             x_pos = self.GetScrollPos(wx.HORIZONTAL)
             y_pos = self.GetScrollPos(wx.VERTICAL)
-            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, x/_PIXELS_PER_UNIT, y/_PIXELS_PER_UNIT, x_pos, y_pos)
+            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, int(x/_PIXELS_PER_UNIT), int(y/_PIXELS_PER_UNIT), x_pos, y_pos)
         
         else:
         
@@ -4573,7 +4573,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
             imglist.Draw(image, dc,
                          item.GetX() + wcheck,
-                         item.GetY() + ((total_h > image_h) and [(total_h-image_h)/2] or [0])[0],
+                         int(item.GetY() + ((total_h > image_h) and [(total_h-image_h)/2] or [0])[0]),
                          wx.IMAGELIST_DRAW_TRANSPARENT)
             
             dc.DestroyClippingRegion()
@@ -4592,7 +4592,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         dc.SetBackgroundMode(wx.TRANSPARENT)
         extraH = ((total_h > text_h) and [(total_h - text_h)/2] or [0])[0]
 
-        textrect = wx.Rect(wcheck + image_w + item.GetX(), item.GetY() + extraH, text_w, text_h)
+        textrect = wx.Rect(wcheck + image_w + item.GetX(), int(item.GetY() + extraH), text_w, text_h)
         
         if not item.IsEnabled():
             foreground = dc.GetTextForeground()
@@ -4856,7 +4856,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
                     if item == self._underMouse:
                         flag |= _CONTROL_CURRENT
 
-                    self._drawingfunction(self, dc, wx.Rect(x_start - wImage/2, y_mid - hImage/2,wImage, hImage), flag)
+                    self._drawingfunction(self, dc, wx.Rect(x_start - int(wImage/2), y_mid - int(hImage/2),wImage, hImage), flag)
                 
 
 

--- a/WikidPad/lib/pwiki/customtreectrl.py
+++ b/WikidPad/lib/pwiki/customtreectrl.py
@@ -3978,7 +3978,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             x += _PIXELS_PER_UNIT + 2 # one more scrollbar unit + 2 pixels
             x_pos = self.GetScrollPos(wx.HORIZONTAL)
             # Item should appear at top
-            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, x/_PIXELS_PER_UNIT, y/_PIXELS_PER_UNIT, x_pos, item_y/_PIXELS_PER_UNIT)
+            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, int(x/_PIXELS_PER_UNIT), int(y/_PIXELS_PER_UNIT), x_pos, int(item_y/_PIXELS_PER_UNIT))
         
         elif item_y+self.GetLineHeight(item) > start_y+client_h:
         
@@ -3989,7 +3989,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             item_y += _PIXELS_PER_UNIT+2
             x_pos = self.GetScrollPos(wx.HORIZONTAL)
             # Item should appear at bottom
-            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, x/_PIXELS_PER_UNIT, y/_PIXELS_PER_UNIT, x_pos, (item_y+self.GetLineHeight(item)-client_h)/_PIXELS_PER_UNIT )
+            self.SetScrollbars(_PIXELS_PER_UNIT, _PIXELS_PER_UNIT, int(x/_PIXELS_PER_UNIT), int(y/_PIXELS_PER_UNIT), x_pos, int((item_y+self.GetLineHeight(item)-client_h)/_PIXELS_PER_UNIT) )
 
 
     def ScrollToMiddle(self, item):

--- a/WikidPad/lib/pwiki/timeView/TimelinePanel.py
+++ b/WikidPad/lib/pwiki/timeView/TimelinePanel.py
@@ -82,11 +82,11 @@ class TimelinePanel(EnhancedListControl, TimePresentationBase):
         self.Bind(wx.EVT_LIST_BEGIN_LABEL_EDIT, self.OnBeginLabelEdit, id=self.GetId())
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.OnEndLabelEdit, id=self.GetId())
         
-        self.Bind(wx.EVT_MENU, self.OnCmdCheckShowEmptyDays, id=GUI_ID.CMD_CHECKBOX_TIMELINE_SHOW_EMPTY_DAYS)
-        self.Bind(wx.EVT_UPDATE_UI, self.OnCmdCheckUpdateEmptyDays, id=GUI_ID.CMD_CHECKBOX_TIMELINE_SHOW_EMPTY_DAYS)
+        self.Bind(wx.EVT_MENU, self.OnCmdCheckShowEmptyDays, source=GUI_ID.CMD_CHECKBOX_TIMELINE_SHOW_EMPTY_DAYS)
+        self.Bind(wx.EVT_UPDATE_UI, self.OnCmdCheckUpdateEmptyDays, source=GUI_ID.CMD_CHECKBOX_TIMELINE_SHOW_EMPTY_DAYS)
 
-        self.Bind(wx.EVT_MENU, self.OnCmdCheckDateAscending, id=GUI_ID.CMD_CHECKBOX_TIMELINE_DATE_ASCENDING)
-        self.Bind(wx.EVT_UPDATE_UI, self.OnCmdCheckUpdateDateAscending, id=GUI_ID.CMD_CHECKBOX_TIMELINE_DATE_ASCENDING)
+        self.Bind(wx.EVT_MENU, self.OnCmdCheckDateAscending, source=GUI_ID.CMD_CHECKBOX_TIMELINE_DATE_ASCENDING)
+        self.Bind(wx.EVT_UPDATE_UI, self.OnCmdCheckUpdateDateAscending, source=GUI_ID.CMD_CHECKBOX_TIMELINE_DATE_ASCENDING)
 
 
 

--- a/WikidPad/lib/pwiki/timeView/VersioningGui.py
+++ b/WikidPad/lib/pwiki/timeView/VersioningGui.py
@@ -111,13 +111,13 @@ class VersionExplorerPanel(EnhancedListControl):
         self.Bind(wx.EVT_SIZE, self.OnSize)
         self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
 
-        self.Bind(wx.EVT_MENU, self.OnCmdDiffInline, id=GUI_ID.CMD_VERSIONING_DIFF_INLINE)
+        self.Bind(wx.EVT_MENU, self.OnCmdDiffInline, source=GUI_ID.CMD_VERSIONING_DIFF_INLINE)
 
-        self.Bind(wx.EVT_MENU, self.OnCmdDiffSetFrom, id=GUI_ID.CMD_VERSIONING_DIFF_SET_FROM)
-        self.Bind(wx.EVT_MENU, self.OnCmdDiffSetTo, id=GUI_ID.CMD_VERSIONING_DIFF_SET_TO)
+        self.Bind(wx.EVT_MENU, self.OnCmdDiffSetFrom, source=GUI_ID.CMD_VERSIONING_DIFF_SET_FROM)
+        self.Bind(wx.EVT_MENU, self.OnCmdDiffSetTo, source=GUI_ID.CMD_VERSIONING_DIFF_SET_TO)
 
-        self.Bind(wx.EVT_MENU, self.OnCmdDeleteVersion, id=GUI_ID.CMD_VERSIONING_DELETE_VERSION)
-        self.Bind(wx.EVT_MENU, self.OnCmdDeleteAllVersionData, id=GUI_ID.CMD_VERSIONING_DELETE_ALL_VERSION_DATA)
+        self.Bind(wx.EVT_MENU, self.OnCmdDeleteVersion, source=GUI_ID.CMD_VERSIONING_DELETE_VERSION)
+        self.Bind(wx.EVT_MENU, self.OnCmdDeleteAllVersionData, source=GUI_ID.CMD_VERSIONING_DELETE_ALL_VERSION_DATA)
 
 #         wx.EVT_UPDATE_UI(self, GUI_ID.CMD_CHECKBOX_TIMELINE_DATE_ASCENDING,
 #                 self.OnCmdCheckUpdateDateAscending)

--- a/WikidPad/lib/pwiki/timeView/WikiWideHistoryGui.py
+++ b/WikidPad/lib/pwiki/timeView/WikiWideHistoryGui.py
@@ -59,7 +59,7 @@ class WikiWideHistoryPanel(EnhancedListControl):
 #         self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
         self.Bind(wx.EVT_MIDDLE_DOWN, self.OnMiddleButtonDown)
         
-        self.Bind(wx.EVT_MENU, self.OnCmdDeleteAll, id=GUI_ID.CMD_WIKI_WIDE_HISTORY_DELETE_ALL)
+        self.Bind(wx.EVT_MENU, self.OnCmdDeleteAll, source=GUI_ID.CMD_WIKI_WIDE_HISTORY_DELETE_ALL)
 
         self.onWikiStateChanged(None)
 

--- a/WikidPad/lib/pwiki/wxHelper.py
+++ b/WikidPad/lib/pwiki/wxHelper.py
@@ -802,6 +802,8 @@ def appendItemToMenuByDescComponents(menu, namePath, idStr, longHelp="",
         menuID = getattr(GUI_ID, idStr, -1)
         if menuID == -1:
             return None
+        if (isinstance(menuID, wxSourceId)):
+            menuID = menuID.GetId()
         longHelp = _unescapeWithRe(longHelp)
 
         return menu.Append(menuID, _(title), _(longHelp), kind)


### PR DESCRIPTION
Make WikidPad run again after encountering https://github.com/WikidPad/WikidPad/issues/82

The core issue was a type mismatch caused by wxSourceId [1] objects, which were passed on [wx.EvtHandler.Bind()](https://docs.wxpython.org/wx.EvtHandler.html#wx.EvtHandler.Bind) and [wx.event.Connect()](https://docs.wxpython.org/wx.EvtHandler.html#wx.EvtHandler.Connect ) function calls from wx instead of integers.

Additionally, I fixed some minor type mismatches between float and int which occured when dividing ints by two to calculated dimension (in pixels) of graphical elements.

With this PR, WikidPad will be able to start with python 3.10 with wxpython 4.0.7

I probably have missed some places where this mismatch occurs. No systematic refactoring was done. This PR implements the bare minimum band aid to make WikidPad functional again. Therefore, this PR is not targeted at the master branch but continues my "work" on branch python3.8plus

[1] https://github.com/WikidPad/WikidPad/blob/558109638807bc76b4672922686e416ab2d5f79c/WikidPad/lib/pwiki/wxHelper.py#L31