### PR TITLE
python3.11 wxpython4.2.0 wxwidgets3.2

### DIFF
--- a/WikidPad/WikidPadStarter.py
+++ b/WikidPad/WikidPadStarter.py
@@ -77,7 +77,7 @@ def _putPathPrepends():
     parser = configparser.RawConfigParser()
     try:
         f = open(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
-                "binInst.ini"), "rU")
+                "binInst.ini"), "r")
         parser.readfp(f)
         f.close()
 

--- a/WikidPad/lib/pwiki/I18nPoUpdater.py
+++ b/WikidPad/lib/pwiki/I18nPoUpdater.py
@@ -13,7 +13,7 @@ def loadEntireTxtFile(filename):
     """
     Load entire file (text mode) and return its content.
     """
-    rf = open(filename, "rU")
+    rf = open(filename, "r")
     try:
         result = rf.read()
         return result

--- a/WikidPad/pygettext.py
+++ b/WikidPad/pygettext.py
@@ -888,7 +888,7 @@ def main(argv):
     for updfile in options.updatefiles:
         utfMode = False
         try:
-            f = open(updfile, "rU")
+            f = open(updfile, "r")
 #             bom = f.read(len(BOM_UTF8))
 #             utfMode = bom == BOM_UTF8  # TODO seek 0 on not UTF
             utfMode = True


### PR DESCRIPTION
Hi,

with python 3.11 the universal newline file mode 'U' was removed (deprecated since py 3.3).
The fix allows wikidpad to start with python 3.11 as default python.

I started naming my branches with the python, wxpython and wxwidgets version I am using while applying the fixes/commits. That way, it may be easier for someone else to checkout the most suitable version combination later on.

Do not accept this PR yet - more fixes may be required.

I am opening this PR "prematurely" to avoid redundant work.