### PR TITLE
Add Python 3.14 CI and fix cross-platform startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux / Python 3.14
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    # Ubuntu 26.04 supplies Python 3.14 and a compatible distro-built
+    # wxPython, avoiding an expensive source build on Linux.
+    container: ubuntu:26.04
+
+    steps:
+      - name: Install test dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+            ca-certificates \
+            git \
+            python3-filetype \
+            python3-pytest \
+            python3-six \
+            python3-wxgtk4.0 \
+            xauth \
+            xvfb
+
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Show runtime versions
+        run: |
+          python3 -c "import sys; assert sys.version_info[:2] == (3, 14); print(sys.version)"
+          python3 -c "import wx; print(wx.version())"
+
+      - name: Compile sources without warnings
+        run: python3 -Werror::SyntaxWarning -m compileall -f -q WikidPad
+
+      - name: Smoke-test application startup
+        run: xvfb-run --auto-servernum python3 WikidPad/tests/smoke_startup.py
+
+      - name: Run tests
+        working-directory: WikidPad
+        run: timeout 180s xvfb-run --auto-servernum python3 -m pytest -q
+
+  windows:
+    name: Windows / Python 3.14
+    runs-on: windows-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.14"
+
+      - name: Install test dependencies
+        run: python -m pip install pytest filetype six wxPython
+
+      - name: Show runtime versions
+        run: |
+          python -c "import sys; assert sys.version_info[:2] == (3, 14); print(sys.version)"
+          python -c "import wx; print(wx.version())"
+
+      - name: Compile sources without warnings
+        run: python -Werror::SyntaxWarning -m compileall -f -q WikidPad
+
+      - name: Smoke-test application startup
+        run: python WikidPad/tests/smoke_startup.py
+
+      - name: Run tests
+        working-directory: WikidPad
+        run: python -m pytest -q

--- a/WikidPad/WikidPad.xrc
+++ b/WikidPad/WikidPad.xrc
@@ -7124,7 +7124,7 @@
       <object class="sizeritem">
         <object class="wxStaticLine"/>
         <option>0</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>5</border>
       </object>
       <object class="sizeritem">
@@ -7147,7 +7147,7 @@
           <label>Page file names ASCII only</label>
         </object>
         <option>0</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>5</border>
       </object>
       <object class="sizeritem">
@@ -7178,7 +7178,7 @@
           </object>
         </object>
         <option>0</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
     </object>
   </object>

--- a/WikidPad/extensions/OverlayParser.pyf
+++ b/WikidPad/extensions/OverlayParser.pyf
@@ -88,13 +88,13 @@ def describeWikiLanguage(ver, app):
 
 PAYLOAD = """
 BracketStart = "[["
-BracketStartPAT = r"\[\["
+BracketStartPAT = r"\\[\\["
 
 BracketEnd = "]]"
-BracketEndPAT = r"\]\]"
+BracketEndPAT = r"\\]\\]"
 
-BracketStartRevPAT = r"\[\["
-BracketEndRevPAT = r"\]\]"
+BracketStartRevPAT = r"\\[\\["
+BracketEndRevPAT = r"\\]\\]"
 """
 
 # add payload for text generator:

--- a/WikidPad/lib/aui/framemanager.py
+++ b/WikidPad/lib/aui/framemanager.py
@@ -3942,7 +3942,7 @@ def GetNotebookRoot(panes, notebook_id):
 
 def EscapeDelimiters(s):
     """
-    Changes ``;`` into ``\`` and ``|`` into ``\|`` in the input string.
+    Changes ``;`` into ``\\`` and ``|`` into ``\\|`` in the input string.
 
     :param string `s`: the string to be analyzed.
 
@@ -10752,5 +10752,4 @@ class AuiManager_DCP(AuiManager):
             # if we get here, there's no center pane, create our dummy
             if not self.hasDummyPane:
                 self._createDummyPane()
-
 

--- a/WikidPad/lib/pwiki/MainApp.py
+++ b/WikidPad/lib/pwiki/MainApp.py
@@ -12,7 +12,9 @@ if not True:
 
 import ExceptionLogger
 
-import wx, wx.adv, wx.xrc
+# Import wx.html before creating wx.App. Importing it afterward makes wxPython
+# 4.3 register its image and animation handlers a second time.
+import wx, wx.adv, wx.html, wx.xrc
 
 # import srePersistent
 # srePersistent.loadCodeCache()

--- a/WikidPad/lib/pwiki/PersonalWikiFrame.py
+++ b/WikidPad/lib/pwiki/PersonalWikiFrame.py
@@ -700,8 +700,12 @@ camelCaseWordsEnabled: false;a=[camelCaseWordsEnabled: false]\\n
 
         lcut = label.split("\t", 1)
         if len(lcut) > 1:
-            lcut[1] = self.translateMenuAccelerator(lcut[1])
-            label = lcut[0] + " \t" + lcut[1]
+            shortcut = lcut[1].strip()
+            if shortcut:
+                shortcut = self.translateMenuAccelerator(shortcut)
+                label = lcut[0] + " \t" + shortcut
+            else:
+                label = lcut[0]
 
 
         menuitem = wx.MenuItem(menu, menuID, label + " ", hint, kind)

--- a/WikidPad/lib/pwiki/PluginManager.py
+++ b/WikidPad/lib/pwiki/PluginManager.py
@@ -1,15 +1,18 @@
 
 
+import importlib
+import importlib.machinery
+import importlib.util
+import os.path
+import sys
+import traceback
+import zipfile
+from functools import reduce
 from zipimport import zipimporter
-import sys, traceback, os.path
 
 import wx
 
-import importlib
-import importlib.util
-
 from .StringOps import mbcsEnc
-from functools import reduce
 
 
 """The PluginManager and PluginAPI classes implement a generic plugin framework.
@@ -360,11 +363,18 @@ class PluginManager:
                                 spec.loader.exec_module(module)
                         elif ext == '.zip':
                             if zipfile.is_zipfile(fullname):
-                                module = importlib.util.module_from_spec(
-                                    importlib.machinery.ModuleSpec(packageName + "." + moduleName, None))
-                                module.__path__ = [fullname]
-                                sys.modules[packageName + "." + moduleName] = module
                                 zi = zipimporter(fullname)
+                                # ZIP plugins are packages whose __init__.py
+                                # may import sibling modules.
+                                spec = importlib.machinery.ModuleSpec(
+                                    packageName + "." + moduleName, zi,
+                                    is_package=True)
+                                module = importlib.util.module_from_spec(
+                                    spec)
+                                module.__path__ = [fullname]
+                                # This is part of the documented ZIP-plugin API.
+                                module.__zippath__ = fullname
+                                sys.modules[packageName + "." + moduleName] = module
                                 co = zi.get_code("__init__")
                                 exec(co, module.__dict__)
 
@@ -372,7 +382,7 @@ class PluginManager:
                         setattr(package, moduleName, module)
                         if hasattr(module, "WIKIDPAD_PLUGIN"):
                             self.registerPlugin(module)
-                except Exception as e:
+                except Exception:
                     traceback.print_exc()
 
     def loadPluginsPackageManaged(self):

--- a/WikidPad/lib/pwiki/SqliteThin3.py
+++ b/WikidPad/lib/pwiki/SqliteThin3.py
@@ -2,6 +2,7 @@
 
 import codecs, types, traceback, sys, os, platform, re
 from ctypes import *
+from ctypes.util import find_library
 
 
 
@@ -90,16 +91,42 @@ class SqliteError3(Exception):
         return "SqliteError "+str(self.err)
 
 
-if isLinux():
-    if sys.hexversion >= 0x02050000:
-        _dll = CDLL("libsqlite3.so.0")
-    else:
-        _dll = CDLL("libsqlite3.so")
-elif platform.uname()[0] == "Darwin":
-    # Mac OS 9 (or 9.1.0 specifically?)
-    _dll = CDLL("libsqlite3.0.dylib")
-else:
-    _dll = cdll.sqlite3
+def _loadSqliteDll():
+    if isLinux():
+        if sys.hexversion >= 0x02050000:
+            return CDLL("libsqlite3.so.0")
+        else:
+            return CDLL("libsqlite3.so")
+    elif platform.uname()[0] == "Darwin":
+        # Mac OS 9 (or 9.1.0 specifically?)
+        return CDLL("libsqlite3.0.dylib")
+
+    found = find_library("sqlite3")
+    if found is not None:
+        try:
+            return CDLL(found)
+        except OSError:
+            pass
+
+    for base in (sys.base_prefix, sys.exec_prefix,
+            os.path.dirname(sys.executable)):
+        dllPath = os.path.join(base, "DLLs", "sqlite3.dll")
+        if os.path.exists(dllPath):
+            try:
+                return CDLL(dllPath)
+            except OSError:
+                pass
+
+    return cdll.sqlite3
+
+
+_dll = _loadSqliteDll()
+
+_dll.sqlite3_initialize.argtypes = ()
+_dll.sqlite3_initialize.restype = c_int
+_initResult = _dll.sqlite3_initialize()
+if _initResult != SQLITE_OK:
+    raise SqliteError3(_initResult)
 
 
 
@@ -821,5 +848,3 @@ def _pyFuncCallback(contextptr, nValues, valueptrptr):
 
         
 _FUNC_CALLBACK = FUNC_CALLBACK_TYPE(_pyFuncCallback)
-
-

--- a/WikidPad/lib/pwiki/WikiPyparsing.py
+++ b/WikidPad/lib/pwiki/WikiPyparsing.py
@@ -79,7 +79,6 @@ import copy, time
 import sys
 import warnings
 import re
-import sre_constants
 import traceback
 
 from .Utilities import DUMBTHREADSTOP
@@ -2332,7 +2331,7 @@ class Regex(Token, NecessaryRegexProvider):
         try:
             self.re = re.compile(self.pattern, self.flags)
             self.reString = self.pattern
-        except sre_constants.error:
+        except re.error:
             warnings.warn("invalid pattern (%s) passed to Regex" % pattern,
                 SyntaxWarning, stacklevel=2)
             raise
@@ -2455,7 +2454,7 @@ class QuotedString(Token, NecessaryRegexProvider):
         try:
             self.re = re.compile(self.pattern, self.flags)
             self.reString = self.pattern
-        except sre_constants.error:
+        except re.error:
             warnings.warn("invalid pattern (%s) passed to Regex" % self.pattern,
                 SyntaxWarning, stacklevel=2)
             raise
@@ -2497,7 +2496,7 @@ class QuotedString(Token, NecessaryRegexProvider):
             if isinstance(ret,str):
                 # replace escaped characters
                 if self.escChar:
-                    ret = re.sub(self.escCharReplacePattern,"\g<1>",ret)
+                    ret = re.sub(self.escCharReplacePattern, r"\g<1>", ret)
 
                 # replace escaped quotes
                 if self.escQuote:

--- a/WikidPad/lib/pwiki/urllib_red.py
+++ b/WikidPad/lib/pwiki/urllib_red.py
@@ -148,7 +148,7 @@ def splitquery(url):
     global _queryprog
     if _queryprog is None:
         import re # import pwiki.srePersistent as reimport pwiki.srePersistent as _re
-        _queryprog = re.compile('^(.*)\?([^?]*)$')
+        _queryprog = re.compile(r'^(.*)\?([^?]*)$')
 
     match = _queryprog.match(url)
     if match: return match.group(1, 2)
@@ -356,4 +356,3 @@ def test1():
     print(repr(qs))
     print(repr(uqs))
     print(round(t1 - t0, 3), 'sec')
-

--- a/WikidPad/lib/pwiki/wxHelper.py
+++ b/WikidPad/lib/pwiki/wxHelper.py
@@ -630,6 +630,11 @@ def getAccelPairFromKeyDown(evt):
 
 
 def getAccelPairFromString(s):
+    # wx logs a warning when asked to parse a menu label without a shortcut.
+    # Empty key bindings are valid and mean that no accelerator is configured.
+    if not s or not s.rsplit("\t", 1)[-1].strip():
+        return (None, None)
+
     ae = wx.AcceleratorEntry()
     if not ae.FromString(s):
         return (None, None)
@@ -648,8 +653,6 @@ def setHotKeyByString(win, hotKeyId, keyString):
 
     accFlags, vkCode = getAccelPairFromString("\t" + keyString)
 
-#     win.RegisterHotKey(hotKeyId, 0, 0)
-    win.UnregisterHotKey(hotKeyId)
     if accFlags is not None:
         modFlags = 0
         if accFlags & wx.ACCEL_SHIFT:

--- a/WikidPad/lib/whoosh/analysis/filters.py
+++ b/WikidPad/lib/whoosh/analysis/filters.py
@@ -53,7 +53,7 @@ url_pattern = rcompile("""
     \\S+?                  # URL body
     (?=\\s|[.]\\s|$|[.]$)  # Stop at space/end, or a dot followed by space/end
 ) | (                      # or...
-    \w+([:.]?\w+)*         # word characters, with opt. internal colons/dots
+    \\w+([:.]?\\w+)*       # word characters, with opt. internal colons/dots
 )
 """, verbose=True)
 
@@ -155,7 +155,7 @@ class TeeFilter(Filter):
     >>> f1 = LowercaseFilter()
     >>> # In the other branch, we'll reverse the tokens
     >>> f2 = ReverseTextFilter()
-    >>> ana = RegexTokenizer(r"\S+") | TeeFilter(f1, f2)
+    >>> ana = RegexTokenizer(r"\\S+") | TeeFilter(f1, f2)
     >>> [token.text for token in ana(target)]
     ["alfa", "AFLA", "bravo", "OVARB", "charlie", "EILRAHC"]
 
@@ -164,7 +164,7 @@ class TeeFilter(Filter):
 
     >>> f1 = PassFilter()
     >>> f2 = BiWordFilter()
-    >>> ana = RegexTokenizer(r"\S+") | TeeFilter(f1, f2) | LowercaseFilter()
+    >>> ana = RegexTokenizer(r"\\S+") | TeeFilter(f1, f2) | LowercaseFilter()
     >>> [token.text for token in ana(target)]
     ["alfa", "alfa-bravo", "bravo", "bravo-charlie", "charlie"]
     """

--- a/WikidPad/lib/whoosh/analysis/intraword.py
+++ b/WikidPad/lib/whoosh/analysis/intraword.py
@@ -46,7 +46,7 @@ class CompoundWordFilter(Filter):
     compound word in the token stream along with the word segments.
 
     >>> cwf = CompoundWordFilter(wordset, keep_compound=True)
-    >>> analyzer = RegexTokenizer(r"\S+") | cwf
+    >>> analyzer = RegexTokenizer(r"\\S+") | cwf
     >>> [t.text for t in analyzer("I do not like greeneggs and ham")
     ["I", "do", "not", "like", "greeneggs", "green", "eggs", "and", "ham"]
     >>> cwf.keep_compound = False
@@ -272,7 +272,7 @@ class IntraWordFilter(Filter):
     >>> iwf_i = IntraWordFilter(mergewords=True, mergenums=True)
     >>> iwf_q = IntraWordFilter(mergewords=False, mergenums=False)
     >>> iwf = MultiFilter(index=iwf_i, query=iwf_q)
-    >>> analyzer = RegexTokenizer(r"\S+") | iwf | LowercaseFilter()
+    >>> analyzer = RegexTokenizer(r"\\S+") | iwf | LowercaseFilter()
 
     (See :class:`MultiFilter`.)
     """
@@ -282,7 +282,7 @@ class IntraWordFilter(Filter):
     __inittypes__ = dict(delims=text_type, splitwords=bool, splitnums=bool,
                          mergewords=bool, mergenums=bool)
 
-    def __init__(self, delims=u("-_'\"()!@#$%^&*[]{}<>\|;:,./?`~=+"),
+    def __init__(self, delims=u("-_'\"()!@#$%^&*[]{}<>\\|;:,./?`~=+"),
                  splitwords=True, splitnums=True,
                  mergewords=False, mergenums=False):
         """

--- a/WikidPad/lib/whoosh/codec/whoosh3.py
+++ b/WikidPad/lib/whoosh/codec/whoosh3.py
@@ -1043,7 +1043,7 @@ class W3LeafMatcher(LeafMatcher):
         vs = self._data[2]
         if fixedsize is None or fixedsize < 0:
             self._values = vs
-        elif fixedsize is 0:
+        elif fixedsize == 0:
             self._values = (None,) * self._blocklength
         else:
             assert isinstance(vs, bytes_type)

--- a/WikidPad/lib/whoosh/lang/paicehusk.py
+++ b/WikidPad/lib/whoosh/lang/paicehusk.py
@@ -30,7 +30,7 @@ class PaiceHuskStemmer(object):
     (?P<cont>[.>])
     """, re.UNICODE | re.VERBOSE)
 
-    stem_expr = re.compile("^\w+", re.UNICODE)
+    stem_expr = re.compile(r"^\w+", re.UNICODE)
 
     def __init__(self, ruletable):
         """

--- a/WikidPad/lib/whoosh/lang/porter2.py
+++ b/WikidPad/lib/whoosh/lang/porter2.py
@@ -64,7 +64,7 @@ def remove_initial_apostrophe(word):
 def capitalize_consonant_ys(word):
     if word.startswith('y'):
         word = 'Y' + word[1:]
-    return ccy_exp.sub('\g<1>Y', word)
+    return ccy_exp.sub(r'\g<1>Y', word)
 
 
 def step_0(word):

--- a/WikidPad/pytest.ini
+++ b/WikidPad/pytest.ini
@@ -2,4 +2,6 @@
 testpaths = tests
 python_files = test_*.py
 norecursedirs = .cache .git .idea icons WikidPadHelp winBinAdditions
+# Prevent the repository-level tests package from shadowing this test suite.
+addopts = --import-mode=importlib
 #addopts = --doctest-modules

--- a/WikidPad/tests/helper.py
+++ b/WikidPad/tests/helper.py
@@ -15,6 +15,7 @@ from itertools import chain
 import os
 import re
 import sys
+from importlib.machinery import SourceFileLoader
 import importlib.util
 import wx
 
@@ -43,9 +44,12 @@ from pwiki.StringOps import LOWERCASE, UPPERCASE
 from wikidPadParser import WikidPadParser
 from mediaWikiParser import MediaWikiParser
 
+# OverlayParser is Python source stored with WikidPad's nonstandard .pyf suffix,
+# so importlib needs an explicit source loader.
 _overlay_parser_path = os.path.join(EXTENSIONDIR, "OverlayParser.pyf")
-_overlay_parser_spec = importlib.util.spec_from_file_location(
-        'OverlayParser', _overlay_parser_path)
+_overlay_parser_spec = importlib.util.spec_from_loader(
+        'OverlayParser',
+        SourceFileLoader('OverlayParser', _overlay_parser_path))
 OverlayParser = importlib.util.module_from_spec(_overlay_parser_spec)
 _overlay_parser_spec.loader.exec_module(OverlayParser)
 

--- a/WikidPad/tests/smoke_startup.py
+++ b/WikidPad/tests/smoke_startup.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Start WikidPad with a real disposable wiki and reject startup errors."""
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+STARTUP_TIMEOUT_SECONDS = 10
+UNEXPECTED_OUTPUT = (
+    "Traceback (most recent call last)",
+    "SyntaxWarning:",
+    "Adding duplicate image handler",
+    "Adding duplicate animation handler",
+    "No accel key found",
+    "UnregisterHotKey' failed",
+)
+
+
+def stop_process(process):
+    process.terminate()
+    try:
+        return process.communicate(timeout=5)[0]
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return process.communicate()[0]
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[2]
+    help_source = repo_root / "WikidPad" / "WikidPadHelp"
+
+    with tempfile.TemporaryDirectory(prefix="wikidpad-startup-") as temp_dir:
+        help_copy = Path(temp_dir) / "WikidPadHelp"
+        shutil.copytree(
+            help_source,
+            help_copy,
+            ignore=shutil.ignore_patterns("*.lock", "*.sli-journal", "__pycache__"),
+        )
+
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(repo_root / "WikidPad.py"),
+                "--wiki",
+                str(help_copy / "WikidPadHelp.wiki"),
+                "--no-recent",
+            ],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+        )
+
+        try:
+            output = process.communicate(timeout=STARTUP_TIMEOUT_SECONDS)[0]
+        except subprocess.TimeoutExpired:
+            output = stop_process(process)
+        else:
+            print(output, end="")
+            raise SystemExit(
+                "WikidPad exited before the startup timeout "
+                f"(status {process.returncode})"
+            )
+
+    found = [message for message in UNEXPECTED_OUTPUT if message in output]
+    if found:
+        print(output, end="")
+        raise SystemExit("Unexpected startup output: " + ", ".join(found))
+
+
+if __name__ == "__main__":
+    main()

--- a/WikidPad/tests/test_DbBackendUtils.py
+++ b/WikidPad/tests/test_DbBackendUtils.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import subprocess
+import sys
+
+from tests import helper  # Sets up WikidPad's import path for pytest importlib mode.
+
+from pwiki.wikidata import DbBackendUtils
+
+
+def test_original_sqlite_handler_available():
+    assert ("original_sqlite", "Original Sqlite") in DbBackendUtils.listHandlers()
+    factory, create = DbBackendUtils.getHandler("original_sqlite")
+    assert factory is not None
+    assert create is not None
+
+
+def test_sqlite_wrapper_opens_database_in_fresh_interpreter():
+    wikidpad_dir = Path(__file__).resolve().parents[1]
+    script = """
+import sys
+sys.path.insert(0, "lib")
+from pwiki import SqliteThin3
+
+database = SqliteThin3.SqliteDb3(":memory:")
+try:
+    database.execute("create table values_to_read (value integer)")
+    database.execute("insert into values_to_read values (42)")
+    statement = database.prepare("select value from values_to_read")
+    try:
+        assert statement.step()
+        print(statement.column_auto(0))
+    finally:
+        statement.close()
+finally:
+    database.close()
+"""
+
+    result = subprocess.run(
+            [sys.executable, "-S", "-c", script],
+            cwd=wikidpad_dir,
+            capture_output=True,
+            text=True,
+            check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "42"

--- a/WikidPad/tests/test_PluginManager.py
+++ b/WikidPad/tests/test_PluginManager.py
@@ -1,0 +1,24 @@
+import zipfile
+
+from lib.pwiki.PluginManager import PluginManager
+
+
+def test_load_zip_plugin_with_relative_import(tmp_path):
+    """ZIP plugins retain their documented package and path behavior."""
+    plugin_path = tmp_path / "sample.zip"
+    with zipfile.ZipFile(plugin_path, "w") as archive:
+        archive.writestr(
+            "__init__.py",
+            "from .helper import VALUE\n"
+            "WIKIDPAD_PLUGIN = (('test', 1),)\n"
+            "def get_value():\n"
+            "    return VALUE, __zippath__\n",
+        )
+        archive.writestr("helper.py", "VALUE = 'loaded'\n")
+
+    manager = PluginManager([str(tmp_path)])
+    api = manager.registerSimplePluginAPI(("test", 1), ["get_value"])
+
+    manager.loadPluginsFixed([])
+
+    assert api.get_value() == [("loaded", str(plugin_path))]

--- a/WikidPad/tests/test_WikidPadParser.py
+++ b/WikidPad/tests/test_WikidPadParser.py
@@ -285,9 +285,6 @@ def test_WikiLinkPath_init():
         msg = '%r -> components = %r != %r'
         return msg % (linkCore, res.components, components)
 
-    def left_to_right_err_msg_3():
-        return '%r !-> %r' % (linkCore, upwardCount)
-
     # ->
     for linkCore, upwardCount, components in tests('left_to_right'):
         if not isinstance(upwardCount, Exception):
@@ -296,14 +293,11 @@ def test_WikiLinkPath_init():
             assert res.components == components, left_to_right_err_msg_2()
         else:
             exc = type(upwardCount)
-            with pytest.raises(exc, message=left_to_right_err_msg_3()):
+            with pytest.raises(exc):
                 WikiLinkPath(linkCore=linkCore)
 
     def right_to_left_err_msg_1():
         return '%d, %r -> %r != %r' % (upwardCount, components, res, linkCore)
-
-    def right_to_left_err_msg_2():
-        return '%d, %r !-> %r' % (upwardCount, components, linkCore)
 
     # <-
     for linkCore, upwardCount, components in tests('right_to_left'):
@@ -313,7 +307,7 @@ def test_WikiLinkPath_init():
             assert res == linkCore, right_to_left_err_msg_1()
         else:
             exc = type(linkCore)
-            with pytest.raises(exc, message=right_to_left_err_msg_2()):
+            with pytest.raises(exc):
                 WikiLinkPath(upwardCount=upwardCount, components=components)
 
 
@@ -491,10 +485,6 @@ def test_WikiLinkPath_join():
         msg = '%r joined with %r != %r'
         return msg % (linkCore, otherLinkCore, joinedLinkCore)
 
-    def err_msg_2():
-        msg = '%r joined with %r !-> %r'
-        return msg % (linkCore, otherLinkCore, joinedLinkCore)
-
     for linkCore, otherLinkCore, joinedLinkCore in tests('left_to_right'):
         linkPath = WikiLinkPath(linkCore=linkCore)
         otherLinkPath = WikiLinkPath(linkCore=otherLinkCore)
@@ -505,7 +495,7 @@ def test_WikiLinkPath_join():
             assert res == joinedPath, err_msg_1()
         else:
             exc = type(joinedLinkCore)
-            with pytest.raises(exc, message=err_msg_2()):
+            with pytest.raises(exc):
                 linkPath.joinTo(otherLinkPath)
 
 
@@ -555,10 +545,6 @@ def test_WikiLinkPath_getRelativePathByAbsPaths():
         msg = 'link to %r on %r = %r != %r'
         return msg % (targetPageName, basePageName, res, linkCore)
 
-    def err_msg_2():
-        msg = 'link to %r on %r !-> %r'
-        return msg % (targetPageName, basePageName, linkCore)
-
     # ->
     for targetPageName, basePageName, linkCore in tests('left_to_right'):
         target = WikiLinkPath(pageName=targetPageName)
@@ -571,7 +557,7 @@ def test_WikiLinkPath_getRelativePathByAbsPaths():
             assert res == linkCore, err_msg_1()
         else:
             exc = type(linkCore)
-            with pytest.raises(exc, message=err_msg_2()):
+            with pytest.raises(exc):
                 WikiLinkPath.getRelativePathByAbsPaths(target, base,
                                                        downwardOnly=False)
 
@@ -703,10 +689,6 @@ def test_WikiLink_resolve_and_create():
         msg = 'ver %d: resolve link %r on %r = %r != %r'
         return msg % (ver, linkCore, basePageName, res, targetPageName)
 
-    def left_to_right_err_msg_2(ver):
-        msg = 'ver %d: link %r on %r !-> %r'
-        return msg % (ver, linkCore, basePageName, targetPageName)
-
     for linkCore, basePageName, targetPageName in tests('left_to_right'):
         if not isinstance(targetPageName, Exception):
             res = resolve_v1(linkCore, basePageName)
@@ -715,9 +697,9 @@ def test_WikiLink_resolve_and_create():
             assert res == targetPageName, left_to_right_err_msg_1(2)
         else:
             exc = type(targetPageName)
-            with pytest.raises(exc, message=left_to_right_err_msg_2(1)):
-                res = resolve_v1(linkCore, basePageName)
-            with pytest.raises(exc, message=left_to_right_err_msg_2(2)):
+            with pytest.raises(exc):
+                resolve_v1(linkCore, basePageName)
+            with pytest.raises(exc):
                 resolve_v2(linkCore, basePageName)
 
     # <-
@@ -740,10 +722,6 @@ def test_WikiLink_resolve_and_create():
         msg = 'ver %d: create link to %r on %r = %r != %r'
         return msg % (ver, targetPageName, basePageName, res, linkCore)
 
-    def right_to_left_err_msg_2(ver):
-        msg = 'ver %d: link to %r on %r !-> %r'
-        return msg % (ver, targetPageName, basePageName, linkCore)
-
     for linkCore, basePageName, targetPageName in tests('right_to_left'):
         if not isinstance(linkCore, Exception):
             absolute = linkCore.startswith('//')
@@ -753,9 +731,9 @@ def test_WikiLink_resolve_and_create():
             assert res == linkCore, right_to_left_err_msg_1(2)
         else:
             exc = type(linkCore)
-            with pytest.raises(exc, message=right_to_left_err_msg_2(1)):
+            with pytest.raises(exc):
                 create_v1(targetPageName, basePageName, False)
-            with pytest.raises(exc, message=right_to_left_err_msg_2(2)):
+            with pytest.raises(exc):
                 create_v2(targetPageName, basePageName, False)
 
 

--- a/WikidPad/tests/test_wxHelper.py
+++ b/WikidPad/tests/test_wxHelper.py
@@ -1,0 +1,32 @@
+from tests import helper  # Sets up WikidPad's import path for pytest importlib mode.
+
+import wx
+
+from pwiki import wxHelper
+
+
+def test_empty_accelerator_is_not_sent_to_wx(capfd):
+    assert wxHelper.getAccelPairFromString("\t") == (None, None)
+    assert "No accel key found" not in capfd.readouterr().err
+
+
+def test_configured_accelerator_is_parsed():
+    flags, key_code = wxHelper.getAccelPairFromString("\tCtrl-S")
+
+    assert flags & wx.ACCEL_CTRL
+    assert key_code == ord("S")
+
+
+def test_hotkey_registration_does_not_unregister_a_fresh_window():
+    registrations = []
+
+    class FreshWindow:
+        def RegisterHotKey(self, hotkey_id, modifiers, key_code):
+            registrations.append((hotkey_id, modifiers, key_code))
+            return True
+
+    window = FreshWindow()
+
+    assert not wxHelper.setHotKeyByString(window, 1, "")
+    assert wxHelper.setHotKeyByString(window, 2, "Ctrl-S")
+    assert registrations == [(2, wx.MOD_CONTROL, ord("S"))]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "WikidPad.WikidPadHelp.files",
         ],
     
-    install_requires =["wxpython>=4.2"],
+    install_requires = ["wxpython>=4.2", "filetype>=1.2", "six>=1.17"],
     
     include_package_data=False,
     package_data={
@@ -88,7 +88,7 @@ setup(
                  'Intended Audience :: End Users/Desktop',
                  'Operating System :: OS Independent',
                  'License :: OSI Approved :: BSD License',
-                 'Programming Language :: Python :: 3.4',
+                 'Programming Language :: Python :: 3.14',
                  'Topic :: Office/Business',],
 
 )


### PR DESCRIPTION
## Summary

Build on benkinooby's Python 3.14.4/wxPython 4.2.5 work with a small, upstream-oriented compatibility and CI layer for Linux and Windows.

The relevant upstream context is WikidPad/WikidPad#77 and the intended integration target is WikidPad/WikidPad#110. This change deliberately stays on that branch rather than introducing a competing migration or release workflow.

The CI lanes exercise Python 3.14, but the important outcome is runtime behavior: WikidPad now opens a real wiki on current 64-bit Windows instead of crashing in the bundled ctypes SQLite wrapper, and the startup path is clean enough for warning-sensitive automation.

## Runtime and dependency compatibility

- Declare `filetype>=1.2` because the `imghdr` replacement imports it during application startup.
- Declare `six>=1.17` because the vendored AUI frame manager imports it.
- Update the package classifier from Python 3.4 to Python 3.14.
- Keep the existing Linux and macOS SQLite library selection, while allowing Windows to discover SQLite through ctypes or the active Python install's `DLLs/sqlite3.dll` before using the historical fallback.
- Call `sqlite3_initialize()` before the first direct SQLite C API operation. CPython's Windows SQLite library can be built without automatic initialization; calling `sqlite3_open()` first caused a native access violation rather than a catchable Python exception.
- Import `wx.html` before constructing the application object so current wxPython does not register image and animation handlers twice.
- Treat an empty configured menu accelerator as "no accelerator" instead of asking wxWidgets to parse it. This removes the repeated `No accel key found` diagnostics without inventing shortcuts.
- Do not unregister a global hotkey on a newly created helper window that did not register it. This removes the Windows `UnregisterHotKey` error while preserving registration of configured hotkeys.
- Remove invalid vertical-alignment flags from expanding XRC sizer items.
- Make invalid escape sequences explicit in the affected parser, URL, AUI, and vendored Whoosh sources without changing their effective strings or regular expressions.
- Replace the deprecated `sre_constants.error` alias with `re.error` and use equality rather than identity for the integer zero check reported by modern Python.

## Plugin and test compatibility

- Import `zipfile` before validating ZIP plugins.
- Give ZIP plugins a package `ModuleSpec`, retain their package path, and restore the documented `__zippath__` global. Relative imports and resource lookup from ZIP plugins therefore work again.
- Load `OverlayParser.pyf` through `SourceFileLoader`; its nonstandard suffix prevents importlib from choosing a source loader by itself.
- Use pytest importlib mode so the repository-level `tests` package does not shadow WikidPad's test package.
- Remove the obsolete `message=` argument from `pytest.raises()` and the dead helper closures that supplied it.
- Add a ZIP-plugin regression covering a relative import and `__zippath__`.
- Add a fresh-interpreter SQLite regression that disables site imports, opens an in-memory database through `SqliteThin3`, writes a value, and reads it back. Running in a subprocess ensures another module cannot initialize SQLite first and hide the Windows crash.
- Add focused accelerator and hotkey tests, including a fake fresh window that intentionally offers no unregister method.

## Startup smoke test

Add one cross-platform Python smoke-test script shared by both CI jobs. It:

1. Copies the real `WikidPadHelp` wiki into a temporary directory.
2. Starts WikidPad against that disposable copy for ten seconds.
3. Fails if the GUI exits early.
4. Rejects tracebacks, `SyntaxWarning`s, duplicate wx handler messages, invalid accelerator messages, and the Windows hotkey error.
5. Terminates the surviving GUI and removes the temporary wiki.

Using a real copied wiki is intentional: merely constructing the main window did not reach the database-open path that crashed on Windows.

## Continuous integration

- Run on pushes and pull requests with read-only repository permissions.
- Pin checkout and setup-python actions to reviewed commit SHAs and disable persisted checkout credentials.
- Add a focused Linux job using an Ubuntu 26.04 container on the stable Ubuntu 24.04 hosted runner. The container supplies Python 3.14 and a distro-built wxPython, avoiding a large source build.
- Add a Windows job using the official Python 3.14 setup action and wxPython wheel. All run steps use Bash; no PowerShell script is introduced.
- Print Python and wxPython versions in both jobs.
- Compile the complete source tree with `SyntaxWarning` promoted to an error.
- Run the shared real-wiki startup smoke test on Windows and under Xvfb on Linux.
- Run the full pytest suite in both jobs, under Xvfb on Linux.
- Bound jobs and the Linux test command so a hung GUI cannot consume a runner indefinitely.

## Local validation

Validated on 64-bit Windows with Python 3.14.7, wxPython 4.3.1/wxWidgets 3.3.3, filetype 1.2.0, six 1.17.0, and pytest 9.1.1:

- `python -m pytest -q`: 27 passed.
- `python -Werror::SyntaxWarning -m compileall -f -q WikidPad`: passed with no output.
- `python WikidPad/tests/smoke_startup.py`: WikidPad remained alive for the full startup window and emitted none of the rejected diagnostics.

## Scope

This is a compatibility baseline, not a packaging or release redesign. It does not claim installer coverage, macOS CI, or exhaustive interactive GUI workflow coverage. Those can be added independently after the Python 3.14 baseline is accepted.